### PR TITLE
Pass a ConfiguredUpkeep to NewUpkeepPayload

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -194,13 +193,9 @@ type UpkeepPayload struct {
 	Trigger Trigger
 }
 
-func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, checkData []byte) UpkeepPayload {
+func NewUpkeepPayload(configuredUpkeep ConfiguredUpkeep, block BlockKey, trigger Trigger, checkData []byte) UpkeepPayload {
 	p := UpkeepPayload{
-		Upkeep: ConfiguredUpkeep{
-			ID:     UpkeepIdentifier(uid.Bytes()),
-			Type:   tp,
-			Config: struct{}{}, // empty struct by default
-		},
+		Upkeep:     configuredUpkeep,
 		CheckBlock: block,
 		Trigger:    trigger,
 		CheckData:  checkData,

--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -204,6 +204,16 @@ func NewUpkeepPayload(configuredUpkeep ConfiguredUpkeep, block BlockKey, trigger
 	return p
 }
 
+type ConfiguredUpkeepConfig struct {
+	MercuryEnabled bool
+}
+
+func (p *UpkeepPayload) EnableMercuryLookup() {
+	p.Upkeep.Config = ConfiguredUpkeepConfig{
+		MercuryEnabled: true,
+	}
+}
+
 func ValidateUpkeepPayload(p UpkeepPayload) error {
 	if len(p.ID) == 0 {
 		return fmt.Errorf("upkeep payload id cannot be empty")

--- a/pkg/basetypes_test.go
+++ b/pkg/basetypes_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestUpkeepPayload_GenerateID(t *testing.T) {
-	payload := NewUpkeepPayload(big.NewInt(111), 1, BlockKey("4"), Trigger{
+	id := big.NewInt(111)
+	payload := NewUpkeepPayload(ConfiguredUpkeep{
+		ID:   UpkeepIdentifier(id.Bytes()),
+		Type: 1,
+	}, BlockKey("4"), Trigger{
 		BlockNumber: 11,
 		BlockHash:   "0x11111",
 		Extension:   "extension111",


### PR DESCRIPTION
In this PR, we're updating the constructor `NewUpkeepPayload` to accept a `ConfiguredUpkeep` parameter. This means callers are able to specify the complete `ConfiguredUpkeep` to be used, rather than specifying as subset of fields for `ConfiguredUpkeep` type.