### PR TITLE
Add a mercury lookup preprocessor

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -192,6 +192,8 @@ type UpkeepPayload struct {
 	CheckData []byte
 	// Trigger is the event that triggered the upkeep to be checked
 	Trigger Trigger
+	// MercuryLookup a flag that determines if a mercury lookup should be performed
+	MercuryLookup bool
 }
 
 func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, checkData []byte) UpkeepPayload {
@@ -207,6 +209,10 @@ func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, che
 	}
 	p.ID = p.GenerateID()
 	return p
+}
+
+func (p *UpkeepPayload) EnableMercuryLookup() {
+	p.MercuryLookup = true
 }
 
 func ValidateUpkeepPayload(p UpkeepPayload) error {

--- a/pkg/v3/flows/conditional.go
+++ b/pkg/v3/flows/conditional.go
@@ -44,11 +44,9 @@ func NewConditionalEligibility(
 	rs ResultStore,
 	ms MetadataStore,
 	rn Runner,
+	preprocessors []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload],
 	logger *log.Logger,
 ) (*ConditionalEligibility, []service.Recoverable, error) {
-	// TODO: add coordinator to preprocessor list
-	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{}
-
 	// runs full check pipeline on a coordinated block with coordinated upkeeps
 	svc0, point := newFinalConditionalFlow(preprocessors, rs, rn, time.Second, logger)
 

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks/build"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks/prebuild"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instructions"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/preprocessors"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/resultstore"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/runner"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/service"
@@ -96,10 +97,17 @@ func newPlugin(
 		},
 	)
 
+	mercuryLookupPreprocessor := preprocessors.NewMercuryPreprocessor(conf.MercuryLookup)
+
+	// TODO: add coordinator to preprocessor list
+	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{
+		mercuryLookupPreprocessor,
+	}
+
 	// create service recoverers to provide panic recovery on dependent services
 	allSvcs := append(svcs, []service.Recoverable{rs, ms, coord, rn, blockTicker}...)
 
-	cFlow, svcs, err := flows.NewConditionalEligibility(ratio, getter, blockSource, builder, rs, ms, rn, logger)
+	cFlow, svcs, err := flows.NewConditionalEligibility(ratio, getter, blockSource, builder, rs, ms, rn, preprocessors, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v3/preprocessors/mercury_lookup.go
+++ b/pkg/v3/preprocessors/mercury_lookup.go
@@ -1,0 +1,31 @@
+package preprocessors
+
+import (
+	"context"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+type mercuryPreprocessor struct {
+	mercuryLookup bool
+}
+
+// NewMercuryPreprocessor returns an instance of the mercury preprocessor
+func NewMercuryPreprocessor(mercuryLookup bool) *mercuryPreprocessor {
+	return &mercuryPreprocessor{
+		mercuryLookup: mercuryLookup,
+	}
+}
+
+func (p *mercuryPreprocessor) PreProcess(_ context.Context, payloads []ocr2keepers.UpkeepPayload) ([]ocr2keepers.UpkeepPayload, error) {
+	var filteredPayloads []ocr2keepers.UpkeepPayload
+
+	for _, payload := range payloads {
+		if p.mercuryLookup {
+			payload.EnableMercuryLookup()
+		}
+		filteredPayloads = append(filteredPayloads, payload)
+	}
+
+	return filteredPayloads, nil
+}

--- a/pkg/v3/preprocessors/mercury_lookup_test.go
+++ b/pkg/v3/preprocessors/mercury_lookup_test.go
@@ -1,0 +1,55 @@
+package preprocessors
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+func TestMercuryPreprocessor_PreProcess(t *testing.T) {
+	t.Run("for a given set of payloads, mercury lookup is enabled as per the config", func(t *testing.T) {
+		p := NewMercuryPreprocessor(true)
+		payloads := []ocr2keepers.UpkeepPayload{
+			ocr2keepers.NewUpkeepPayload(big.NewInt(1), 1, ocr2keepers.BlockKey("123"), ocr2keepers.Trigger{
+				BlockNumber: 123,
+				BlockHash:   "abc",
+			}, []byte{}),
+			ocr2keepers.NewUpkeepPayload(big.NewInt(2), 1, ocr2keepers.BlockKey("456"), ocr2keepers.Trigger{
+				BlockNumber: 456,
+				BlockHash:   "def",
+			}, []byte{}),
+		}
+
+		assert.False(t, payloads[0].MercuryLookup)
+		assert.False(t, payloads[1].MercuryLookup)
+		payloads, err := p.PreProcess(context.Background(), payloads)
+		assert.NoError(t, err)
+		assert.True(t, payloads[0].MercuryLookup)
+		assert.True(t, payloads[1].MercuryLookup)
+	})
+
+	t.Run("for a given set of payloads, mercury lookup is not enabled as per the config", func(t *testing.T) {
+		p := NewMercuryPreprocessor(false)
+		payloads := []ocr2keepers.UpkeepPayload{
+			ocr2keepers.NewUpkeepPayload(big.NewInt(1), 1, ocr2keepers.BlockKey("123"), ocr2keepers.Trigger{
+				BlockNumber: 123,
+				BlockHash:   "abc",
+			}, []byte{}),
+			ocr2keepers.NewUpkeepPayload(big.NewInt(2), 1, ocr2keepers.BlockKey("456"), ocr2keepers.Trigger{
+				BlockNumber: 456,
+				BlockHash:   "def",
+			}, []byte{}),
+		}
+
+		assert.False(t, payloads[0].MercuryLookup)
+		assert.False(t, payloads[1].MercuryLookup)
+		payloads, err := p.PreProcess(context.Background(), payloads)
+		assert.NoError(t, err)
+		assert.False(t, payloads[0].MercuryLookup)
+		assert.False(t, payloads[1].MercuryLookup)
+	})
+}


### PR DESCRIPTION
In this PR, we're adding a new preprocessor in the plugin, which will be used in the conditional eligibility flow, that will enable mercury lookup on the upkeep payloads, if mercury lookup is enabled on the offchain config

