### PR TITLE
Optimize Sorting: shuffle string chars only once per workID

### DIFF
--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -27,7 +27,7 @@ type AddFromStagingHook struct {
 }
 
 // RunHook adds results from the store to the observation.
-// It sorts by a shuffled workID. workID for all items is shuffled using a pseduorandom souce
+// It sorts by a shuffled workID. workID for all items is shuffled using a pseudorandom source
 // that is the same across all nodes for a given round. This ensures that all nodes try to
 // send the same subset of workIDs if they are available, while giving different priority
 // to workIDs in different rounds.

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -46,7 +46,7 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 		shuffledIDs[result.WorkID] = random.ShuffleString(result.WorkID, rSrc)
 	}
 	// sort by the shuffled workID
-	sort.SliceStable(results, func(i, j int) bool {
+	sort.Slice(results, func(i, j int) bool {
 		return shuffledIDs[results[i].WorkID] < shuffledIDs[results[j].WorkID]
 	})
 	if len(results) > limit {

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -57,9 +57,3 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 
 	return nil
 }
-
-// shuffledString represents a string that has been shuffled using a pseduorandom source
-type shuffledString struct {
-	val       string
-	origIndex int
-}

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"testing"
 
@@ -183,4 +184,66 @@ func TestAddFromStagingHook_RunHook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddFromStagingHook_RunHook_Limits(t *testing.T) {
+	tests := []struct {
+		name     string
+		n        int
+		limit    int
+		expected int
+	}{
+		{
+			name:     "limit is less than results",
+			n:        1000,
+			limit:    100,
+			expected: 100,
+		},
+		{
+			name:     "limit is greater than results",
+			n:        100,
+			limit:    200,
+			expected: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockResultStore, mockCoordinator := getMocks(tt.n)
+			var logBuf bytes.Buffer
+			logger := log.New(&logBuf, "", 0)
+			addFromStagingHook := NewAddFromStagingHook(mockResultStore, mockCoordinator, logger)
+
+			rSrc := [16]byte{1, 1, 2, 2, 3, 3, 4, 4}
+			obs := &ocr2keepersv3.AutomationObservation{}
+
+			err := addFromStagingHook.RunHook(obs, tt.limit, rSrc)
+			assert.NoError(t, err)
+			assert.Len(t, obs.Performable, tt.expected)
+
+			// Run the hook again with the same random source
+			// and assert that the results are the same
+			mockResultStore2, mockCoordinator2 := getMocks(tt.n)
+			addFromStagingHook2 := NewAddFromStagingHook(mockResultStore2, mockCoordinator2, logger)
+
+			obs2 := &ocr2keepersv3.AutomationObservation{}
+			err2 := addFromStagingHook2.RunHook(obs2, tt.limit, rSrc)
+			assert.NoError(t, err2)
+			assert.Len(t, obs.Performable, tt.expected)
+			assert.Equal(t, obs.Performable, obs2.Performable)
+		})
+	}
+}
+
+func getMocks(n int) (*mocks.MockResultStore, *mocks.MockCoordinator) {
+	mockResults := make([]types.CheckResult, n)
+	for i := 0; i < n; i++ {
+		mockResults[i] = types.CheckResult{UpkeepID: [32]byte{uint8(i)}, WorkID: fmt.Sprintf("10%d", i)}
+	}
+	mockResultStore := &mocks.MockResultStore{}
+	mockResultStore.On("View").Return(mockResults, nil)
+	mockCoordinator := &mocks.MockCoordinator{}
+	mockCoordinator.On("FilterResults", mock.Anything).Return(mockResults, nil)
+
+	return mockResultStore, mockCoordinator
 }


### PR DESCRIPTION
AUTO-7299

#### Description

As part of load testing, we found that our sorting doesn’t scale well as it takes too much CPU.
The motivation in this PR is to avoid shuffle the workID string multiple times, by doing it only once.

#### Changes

- `AddFromStagingHook` is using an additional slice to hold the shuffled strings, and sort that slice instead of the original one that requires to shuffle the workID in each sort operation (up to `n^2` operations)

#### Testing

There were no new tests added as the current cases cover this change and ensure we didn't break the function