### PR TITLE
adjust maxObservation and maxOutcome based on performData size

### DIFF
--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -12,13 +12,13 @@ import (
 // as different nodes would upgrade at different times and would need to
 // adhere to each others' limits
 const (
-	ObservationPerformablesLimit          = 100
+	ObservationPerformablesLimit          = 50
 	ObservationLogRecoveryProposalsLimit  = 5
 	ObservationConditionalsProposalsLimit = 5
 	ObservationBlockHistoryLimit          = 256
 
 	// MaxObservationLength applies a limit to the total length of bytes in an
-	// observation. NOTE: This is derived from a limit of 5000 on performData
+	// observation. NOTE: This is derived from a limit of 10000 on performData
 	// which is guaranteed onchain
 	MaxObservationLength = 1_000_000
 )

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -546,7 +546,7 @@ func TestLargeObservationSize(t *testing.T) {
 			Hash:   [32]byte{1},
 		})
 	}
-	largePerformData := [5001]byte{}
+	largePerformData := [10001]byte{}
 	for i := 0; i < ObservationPerformablesLimit; i++ {
 		newResult := validLogResult
 		uid := types.UpkeepIdentifier{}

--- a/pkg/v3/outcome.go
+++ b/pkg/v3/outcome.go
@@ -19,9 +19,9 @@ const (
 	OutcomeSurfacedProposalsRoundHistoryLimit = 20
 
 	// MaxOutcomeLength applies a limit to the total length of bytes in an outcome for
-	// a round. NOTE: This is derived from a limit of 5000 on performData
+	// a round. NOTE: This is derived from a limit of 10000 on performData
 	// which is guaranteed onchain
-	MaxOutcomeLength = 2_000_000
+	MaxOutcomeLength = 2_500_000
 	// MaxReportLength limits the total length of bytes for a single report.
 	MaxReportLength = 1_000_000
 	// MaxReportCount limits the total number of reports allowed to be produced

--- a/pkg/v3/outcome_test.go
+++ b/pkg/v3/outcome_test.go
@@ -120,7 +120,7 @@ func TestLargeOutcomeSize(t *testing.T) {
 		AgreedPerformables: []types.CheckResult{},
 		SurfacedProposals:  [][]types.CoordinatedBlockProposal{},
 	}
-	largePerformData := [5001]byte{}
+	largePerformData := [10001]byte{}
 	for i := 0; i < OutcomeAgreedPerformablesLimit; i++ {
 		newResult := validLogResult
 		uid := types.UpkeepIdentifier{}


### PR DESCRIPTION
AUTO-7596

This is a dup of https://github.com/smartcontractkit/chainlink-automation/pull/292 on top of 2.7.2-fix branch to be pushed in hotfix