### PR TITLE
Upkeep Simulator Assertions

### DIFF
--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -324,7 +324,8 @@ matches the `triggerValue` of a `logTrigger` event, this upkeep is 'triggered' b
 
 An upkeep may or may not be expected to perform even though the upkeep is eligible. This may be due to other configured
 components of the simulation and provides a way to do negative assertions. That is, an assertion that upkeeps DID NOT
-perform. Available options include `all` and `none`. Default is `all`.
+perform. Available options include `all` and `none`. Default is `all`. In the future there might be other options such
+as percentage or quantity.
 
 #### Log Events
 

--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -1,32 +1,27 @@
 # Simulator
 
-The goal of the simulator is to complete a full run of the automation plugin
-without using a chain, p2p network, RPC providers, or chainlink node as
-dependencies. What is being tested in this simulator is how the plugin 
-interfaces with `libOCR` and how multiple instances interact to achieve a quorum
-on tasks.
+The goal of the simulator is to complete a full run of the automation plugin without using a chain, p2p network, RPC
+providers, or chainlink node as dependencies. What is being tested in this simulator is how the plugin interfaces
+with `libOCR` and how multiple instances interact to achieve a quorum on tasks.
 
-Use this tool to validate the plugin protocol **only** since the chain and
-network layers are both fully simulated and do not match real instances 1:1.
+Use this tool to validate the plugin protocol **only** since the chain and network layers are both fully simulated and
+do not match real instances 1:1.
 
-The simulator uses runbooks to control some of the underlying simulations such
-as p2p network latency, block production, upkeep schedules, and more.
+The simulator uses runbooks to control some of the underlying simulations such as p2p network latency, block
+production, upkeep schedules, and more.
 
 ## Usage
 
-The current iteration of the simulator requires a full build before a run as the
-simulator doesn't run binaries of the plugin, but instead the plugin is built
-within the simulator binary. The current limitation is that multiple custom
-builds cannot be run as part of a combined network. All instances in the 
-simulated network will be identical.
+The current iteration of the simulator requires a full build before a run since the simulator doesn't run binaries of
+the plugin. Instead the plugin is built within the simulator binary. The current limitation is that multiple custom
+builds cannot be run as part of a combined network. All instances in the simulated network will be identical.
 
-Outputs can be directed to a specific directory, which is advised since each
-instance produces its own log files. With more than 4 instances running for
-long periods of time, these log files can become large. Logging is full debug
+Outputs can be directed to a specific directory, which is advised since each instance produces its own log files. With
+more than 4 instances running for long periods of time, these log files can become large. Logging is full debug
 by default.
 
-Charts are useful to visualize RPC failures and overall simulated latency, both
-p2p and RPC. The charts are provided by an HTTP endpoint on localhost.
+Charts are useful to visualize RPC failures and overall simulated latency, both p2p and RPC. The charts are provided
+by an HTTP endpoint on localhost.
 
 *Example*
 ```
@@ -42,11 +37,20 @@ $ ./bin/simulator --simulate -f ./tools/simulator/plans/simplan_fast_check.json
 - `--pprof [bool]`: default false, run pprof server on simulation startup
 - `--pprof-port [int]`: default 6060, port to serve pprof profiler on
 
+### Assertions and Exit Status
+
+Exit status of any simulation is dictated by assertions on whether or not eligible upkeeps were performed. Both positive
+and negative assertions are possible by configuring upkeep perform expectations. A negative assertion would be one where
+it is expected that no upkeeps are performed, which can be accomplished by altering network variables such as the
+simulated RPC or not sending an OCR config event.
+
+All simulations will return an exit status, which is used in CI runs to indicate success or failure of a simulation
+plan.
+
 ## Profiling
 
-Start the service in one terminal window and run the pprof tool in another. For
-more information on pprof, view some docs
-[here](https://github.com/google/pprof/blob/main/doc/README.md) to get started.
+Start the service in one terminal window and run the pprof tool in another. For more information on pprof, view some
+docs [here](https://github.com/google/pprof/blob/main/doc/README.md) to get started.
 
 ```
 # terminal 1
@@ -314,6 +318,13 @@ Options are `conditional` and `logTrigger`.
 
 This value applies to a log trigger type upkeep and is the reference point for a `logTrigger` event. If this value
 matches the `triggerValue` of a `logTrigger` event, this upkeep is 'triggered' by the log trigger event.
+
+*expected*
+[string]
+
+An upkeep may or may not be expected to perform even though the upkeep is eligible. This may be due to other configured
+components of the simulation and provides a way to do negative assertions. That is, an assertion that upkeeps DID NOT
+perform. Available options include `all` and `none`. Default is `all`.
 
 #### Log Events
 

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -165,10 +165,10 @@ func main() {
 
 	wg.Wait()
 
-	fmt.Printf("\nSimulation done")
-
 	if !progress.AllProgressComplete() {
 		fmt.Println("\nsimulation failed")
 		os.Exit(1)
 	}
+
+	fmt.Printf("\nSimulation done")
 }

--- a/tools/simulator/config/event.go
+++ b/tools/simulator/config/event.go
@@ -2,6 +2,11 @@ package config
 
 import "math/big"
 
+const (
+	AllExpected  = "all"
+	NoneExpected = "none"
+)
+
 type EventType string
 
 const (
@@ -79,6 +84,14 @@ type GenerateUpkeepEvent struct {
 	// upkeeps. Only applies to log trigger type upkeeps. An empty value for a
 	// log triggered upkeep will result in the upkeep never being triggered.
 	LogTriggeredBy string `json:"logTriggeredBy,omitempty"`
+	// Expected provides customizations to upkeep perform assertions. By default
+	// all eligible upkeeps are expected to be performed where the default value
+	// in this configuration is 'all'. The alternative is 'none' where none of
+	// generated upkeeps are expected to perform. Use the latter when creating
+	// upkeeps that should perform per the eligibility configuration, but will
+	// not perform due to some other network concerns such as too high network
+	// delay or something that might disable the OCR3 protocol.
+	Expected string `json:"expected,omitempty"`
 }
 
 // LogTriggerEvent is a configuration for simulating logs emitted from a chain

--- a/tools/simulator/config/simulation.go
+++ b/tools/simulator/config/simulation.go
@@ -99,6 +99,10 @@ func DecodeSimulationPlan(encoded []byte) (SimulationPlan, error) {
 				return plan, fmt.Errorf("%w: failed to decode generateUpkeep event in simulation plan at index %d: %s", ErrEncoding, idx, err.Error())
 			}
 
+			if generateEvent.Expected == "" {
+				generateEvent.Expected = AllExpected
+			}
+
 			plan.GenerateUpkeeps = append(plan.GenerateUpkeeps, generateEvent)
 		case LogTriggerEventType:
 			var logEvent LogTriggerEvent

--- a/tools/simulator/plans/simplan_failed_rpc.json
+++ b/tools/simulator/plans/simplan_failed_rpc.json
@@ -1,0 +1,81 @@
+{
+    "node": {
+        "totalNodeCount": 4,
+        "maxNodeServiceWorkers": 100,
+        "maxNodeServiceQueueSize": 1000
+    },
+    "p2pNetwork": {
+        "maxLatency": "100ms"
+    },
+    "rpc": {
+        "maxBlockDelay": 600,
+        "averageLatency": 300,
+        "errorRate": 1.0,
+        "rateLimitThreshold": 1000
+    },
+    "blocks": {
+        "genesisBlock": 128943862,
+        "blockCadence": "1s",
+        "durationInBlocks": 30,
+        "endPadding": 10
+    },
+    "events": [
+        {
+            "type": "ocr3config",
+            "eventBlockNumber": 128943863,
+            "comment": "initial ocr config (valid)",
+            "maxFaultyNodes": 1,
+            "encodedOffchainConfig": "{\"version\":\"v3\",\"performLockoutWindow\":100000,\"targetProbability\":\"0.999\",\"targetInRounds\":4,\"minConfirmations\":1,\"gasLimitPerReport\":1000000,\"gasOverheadPerUpkeep\":300000,\"maxUpkeepBatchSize\":10}",
+            "maxRoundsPerEpoch": 7,
+            "deltaProgress": "10s",
+            "deltaResend": "10s",
+            "deltaInitial": "300ms",
+            "deltaRound": "1100ms",
+            "deltaGrace": "300ms",
+            "deltaCertifiedCommitRequest": "200ms",
+            "deltaStage": "20s",
+            "maxQueryTime": "50ms",
+            "maxObservationTime": "100ms",
+            "maxShouldAcceptTime": "50ms",
+            "maxShouldTransmitTime": "50ms"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943862,
+            "comment": "~3 performs per upkeep",
+            "count": 10,
+            "startID": 200,
+            "eligibilityFunc": "30x - 15",
+            "offsetFunc": "2x + 1",
+            "upkeepType": "conditional",
+            "expected": "none"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943862,
+            "comment": "single log triggered upkeep",
+            "count": 1,
+            "startID": 300,
+            "eligibilityFunc": "always",
+            "upkeepType": "logTrigger",
+            "logTriggeredBy": "test_trigger_event",
+            "expected": "none"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943882,
+            "comment": "single log triggered upkeep",
+            "count": 1,
+            "startID": 400,
+            "eligibilityFunc": "never",
+            "upkeepType": "logTrigger",
+            "logTriggeredBy": "test_trigger_event"
+        },
+        {
+            "type": "logTrigger",
+            "eventBlockNumber": 128943872,
+            "comment": "trigger 10 blocks after trigger upkeep created",
+            "triggerValue": "test_trigger_event"
+        }
+    ]
+}

--- a/tools/simulator/simulate/chain/block.go
+++ b/tools/simulator/simulate/chain/block.go
@@ -49,6 +49,7 @@ type SimulatedUpkeep struct {
 	EligibleAt     []*big.Int
 	TriggeredBy    string
 	CheckData      []byte
+	Expected       bool
 }
 
 type SimulatedLog struct {

--- a/tools/simulator/simulate/chain/generate.go
+++ b/tools/simulator/simulate/chain/generate.go
@@ -83,6 +83,7 @@ func generateBasicSimulatedUpkeeps(event config.GenerateUpkeepEvent, alwaysEligi
 			AlwaysEligible: alwaysEligible,
 			EligibleAt:     make([]*big.Int, 0),
 			TriggeredBy:    event.LogTriggeredBy,
+			Expected:       event.Expected == config.AllExpected,
 		}
 
 		generated = append(generated, simulated)
@@ -112,6 +113,7 @@ func generateEligibilityFuncSimulatedUpkeeps(event config.GenerateUpkeepEvent, s
 			AlwaysEligible: false,
 			EligibleAt:     make([]*big.Int, 0),
 			TriggeredBy:    event.LogTriggeredBy,
+			Expected:       event.Expected == config.AllExpected,
 		}
 
 		var genesis *big.Int


### PR DESCRIPTION
To accomplish basic negative assertions, a new config parameter was added to upkeep generation events. The new parameter `expected` indicates whether or not the generated upkeeps are expected to be performed even if they are eligible. If `expected` is set to `none` and at least one upkeep is performed, the simulation will return with a non-successful exit status.