### PR TITLE
Verbose Simulation Output

### DIFF
--- a/SIMULATOR.md
+++ b/SIMULATOR.md
@@ -12,20 +12,6 @@ network layers are both fully simulated and do not match real instances 1:1.
 The simulator uses runbooks to control some of the underlying simulations such
 as p2p network latency, block production, upkeep schedules, and more.
 
-## Profiling
-
-Start the service in one terminal window and run the pprof tool in another. For
-more information on pprof, view some docs
-[here](https://github.com/google/pprof/blob/main/doc/README.md) to get started.
-
-```
-# terminal 1
-$ ./bin/simulator --pprof --simulate -f ./tools/simulator/plans/simplan_fast_check.json
-
-# terminal 2
-$ go tool pprof -top http://localhost:6060/debug/pprof/heap
-```
-
 ## Usage
 
 The current iteration of the simulator requires a full build before a run as the
@@ -50,10 +36,25 @@ $ ./bin/simulator --simulate -f ./tools/simulator/plans/simplan_fast_check.json
 *Options*
 - `--simulation-file | -f [string]`: default ./simulation_plan.json, path to JSON file defining simulation parameters
 - `--output-directory | -o [string]`: default ./simulation_logs, path to output directory where run logs are written
+- `--verbose [bool]`: default false, make output verbose (prints logs to output directory)
 - `--simulate [bool]`: default false, run simulation and output results
 - `--charts [bool]`: default false, start and run charts service to display results
 - `--pprof [bool]`: default false, run pprof server on simulation startup
 - `--pprof-port [int]`: default 6060, port to serve pprof profiler on
+
+## Profiling
+
+Start the service in one terminal window and run the pprof tool in another. For
+more information on pprof, view some docs
+[here](https://github.com/google/pprof/blob/main/doc/README.md) to get started.
+
+```
+# terminal 1
+$ ./bin/simulator --pprof --simulate -f ./tools/simulator/plans/simplan_fast_check.json
+
+# terminal 2
+$ go tool pprof -top http://localhost:6060/debug/pprof/heap
+```
 
 ## Simulation Plan
 

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -26,6 +26,7 @@ import (
 var (
 	simulationFile  = flag.StringP("simulation-file", "f", "./simulation_plan.json", "file path to read simulation config from")
 	outputDirectory = flag.StringP("output-directory", "o", "./simulation_plan_logs", "directory path to output log files")
+	verbose         = flag.BoolP("verbose", "v", false, "make output verbose (prints logs to output directory)")
 	simulate        = flag.Bool("simulate", false, "run simulation")
 	serveCharts     = flag.Bool("charts", false, "create and serve charts")
 	profiler        = flag.Bool("pprof", false, "run pprof server on startup")
@@ -53,7 +54,7 @@ func main() {
 	}
 
 	// ----- setup simulation output directory and file handles
-	outputs, err := run.SetupOutput(*outputDirectory, *simulate, plan)
+	outputs, err := run.SetupOutput(*outputDirectory, *simulate, *verbose, plan)
 	if err != nil {
 		procLog.Printf("failed to setup output directory: %s", err)
 		os.Exit(1)

--- a/tools/simulator/node/stats.go
+++ b/tools/simulator/node/stats.go
@@ -24,7 +24,6 @@ func newUpkeepStatsBuilder(
 	checks map[string][]string,
 	encoder ocr2keepers.Encoder,
 ) (*upkeepStatsBuilder, error) {
-
 	// count the number of transmits per account
 	accTr := make(map[string]int)
 
@@ -85,7 +84,6 @@ func (b *upkeepStatsBuilder) UpkeepIDs() []string {
 		srcUpkeepID := ocr2keepers.UpkeepIdentifier(upkeep.UpkeepID)
 
 		for _, upkeepID := range allIDs {
-
 			if upkeepID == srcUpkeepID.String() {
 				found = true
 			}

--- a/tools/simulator/telemetry/contract.go
+++ b/tools/simulator/telemetry/contract.go
@@ -13,24 +13,20 @@ type ContractEventCollector struct {
 	// dependencies
 	logger *log.Logger
 
-	// configuration
-	filePath string
-
 	// internal state properties
 	mu    sync.RWMutex
 	nodes map[string]*WrappedContractCollector
 }
 
-func NewContractEventCollector(path string, logger *log.Logger) *ContractEventCollector {
+func NewContractEventCollector(logger *log.Logger) *ContractEventCollector {
 	return &ContractEventCollector{
 		baseCollector: baseCollector{
 			t:        NodeLogType,
 			io:       []io.WriteCloser{},
 			ioLookup: make(map[string]int),
 		},
-		logger:   log.New(logger.Writer(), "[contract-event-collector]", log.Ldate|log.Ltime|log.Lshortfile),
-		filePath: path,
-		nodes:    make(map[string]*WrappedContractCollector),
+		logger: log.New(logger.Writer(), "[contract-event-collector]", log.Ldate|log.Ltime|log.Lshortfile),
+		nodes:  make(map[string]*WrappedContractCollector),
 	}
 }
 

--- a/tools/simulator/telemetry/rpc.go
+++ b/tools/simulator/telemetry/rpc.go
@@ -20,14 +20,16 @@ import (
 type RPCCollector struct {
 	baseCollector
 	filePath string
+	verbose  bool
 	nodes    map[string]*WrappedRPCCollector
 }
 
-func NewNodeRPCCollector(path string) *RPCCollector {
+func NewNodeRPCCollector(path string, verbose bool) *RPCCollector {
 	return &RPCCollector{
 		baseCollector: baseCollector{
 			t: RPCType,
 		},
+		verbose:  verbose,
 		filePath: path,
 		nodes:    make(map[string]*WrappedRPCCollector),
 	}
@@ -45,6 +47,10 @@ func (c *RPCCollector) AddNode(node string) error {
 }
 
 func (c *RPCCollector) WriteResults() error {
+	if !c.verbose {
+		return nil
+	}
+
 	for key, node := range c.nodes {
 		path := fmt.Sprintf("%s/%s", c.filePath, key)
 		err := os.MkdirAll(path, 0750)
@@ -158,6 +164,10 @@ func (c *RPCCollector) collectDataFromFile() ([]string, map[string][]rpcDataPoin
 	ids := []string{}
 	rateData := make(map[string][]rpcDataPoint)
 	path := c.filePath
+
+	if !c.verbose {
+		return ids, rateData, fmt.Errorf("verbose logging not activated")
+	}
 
 	files, err := os.ReadDir(path)
 	if err != nil {


### PR DESCRIPTION
By default, the simulation output was already verbose by printing logs for each node to separate files and printing simulation output to a file.

This change makes verbose no longer default and adds an option to do verbose logging output.