### PR TITLE
Dynamically calculate performables limit based on perform data size

### DIFF
--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -46,6 +46,9 @@ func (observation AutomationObservation) Encode() ([]byte, error) {
 }
 
 func DecodeAutomationObservation(data []byte, utg ocr2keepers.UpkeepTypeGetter, wg ocr2keepers.WorkIDGenerator) (AutomationObservation, error) {
+	if len(data) > MaxObservationLength {
+		return AutomationObservation{}, fmt.Errorf("observation size cannot be greater than %d; has %d bytes", MaxObservationLength, len(data))
+	}
 	ao := AutomationObservation{}
 	err := json.Unmarshal(data, &ao)
 	if err != nil {
@@ -73,9 +76,6 @@ func validateAutomationObservation(o AutomationObservation, utg ocr2keepers.Upke
 	}
 
 	// Validate Performables
-	if (len(o.Performable)) > ObservationPerformablesLimit {
-		return fmt.Errorf("performable length cannot be greater than %d", ObservationPerformablesLimit)
-	}
 	seenPerformables := make(map[string]bool)
 	for _, res := range o.Performable {
 		if err := validateCheckResult(res, utg, wg); err != nil {

--- a/pkg/v3/outcome.go
+++ b/pkg/v3/outcome.go
@@ -53,9 +53,6 @@ type AutomationOutcome struct {
 // ValidateAutomationOutcome validates individual values in an AutomationOutcome
 func validateAutomationOutcome(o AutomationOutcome, utg ocr2keepers.UpkeepTypeGetter, wg ocr2keepers.WorkIDGenerator) error {
 	// Validate AgreedPerformables
-	if (len(o.AgreedPerformables)) > OutcomeAgreedPerformablesLimit {
-		return fmt.Errorf("outcome performable length cannot be greater than %d", OutcomeAgreedPerformablesLimit)
-	}
 	seenPerformables := make(map[string]bool)
 	for _, res := range o.AgreedPerformables {
 		if err := validateCheckResult(res, utg, wg); err != nil {
@@ -87,6 +84,7 @@ func validateAutomationOutcome(o AutomationOutcome, utg ocr2keepers.UpkeepTypeGe
 			seenProposals[proposal.WorkID] = true
 		}
 	}
+
 	return nil
 }
 
@@ -99,6 +97,9 @@ func (outcome AutomationOutcome) Encode() ([]byte, error) {
 // DecodeAutomationOutcome decodes an AutomationOutcome from an encoded array
 // of bytes. Possible errors come from the encoding/json package
 func DecodeAutomationOutcome(data []byte, utg ocr2keepers.UpkeepTypeGetter, wg ocr2keepers.WorkIDGenerator) (AutomationOutcome, error) {
+	if len(data) > MaxOutcomeLength {
+		return AutomationOutcome{}, fmt.Errorf("outcome size cannot be greater than %d bytes; has %d bytes", MaxOutcomeLength, len(data))
+	}
 	ao := AutomationOutcome{}
 	err := json.Unmarshal(data, &ao)
 	if err != nil {

--- a/pkg/v3/outcome.go
+++ b/pkg/v3/outcome.go
@@ -22,6 +22,9 @@ const (
 	// a round. NOTE: This is derived from a limit of 10000 on performData
 	// which is guaranteed onchain
 	MaxOutcomeLength = 2_500_000
+	// maxOutcomeProposalsLength is the maximum length of bytes for all proposals in an outcome
+	MaxOutcomeProposalsLength = OutcomeSurfacedProposalsLimit * OutcomeSurfacedProposalsRoundHistoryLimit *
+		(32 + 32 + (32 + 8 + 32 + 4 + 32 + 8)) // upkeepID + workID + trigger (blockNumber + blockHash + logTriggerExtension)
 	// MaxReportLength limits the total length of bytes for a single report.
 	MaxReportLength = 1_000_000
 	// MaxReportCount limits the total number of reports allowed to be produced

--- a/pkg/v3/outcome_test.go
+++ b/pkg/v3/outcome_test.go
@@ -63,14 +63,14 @@ func TestLargeAgreedPerformables(t *testing.T) {
 			size += p.Size()
 		}
 	}
-	for i := 0; size < MaxOutcomeLength; i++ {
+	for i := 0; size+10 < MaxOutcomeLength; i++ {
 		newResult := validLogResult
 		uid := types.UpkeepIdentifier{}
-		uid.FromBigInt(big.NewInt(int64(i + 10001)))
+		uid.FromBigInt(big.NewInt(int64((i + 1) + 10001)))
 		newResult.UpkeepID = uid
-		newResult.Trigger.BlockNumber = types.BlockNumber(i + 1)
+		newResult.Trigger.BlockNumber = types.BlockNumber(i + 1001)
 		newResult.WorkID = mockWorkIDGenerator(newResult.UpkeepID, newResult.Trigger)
-		ao.AgreedPerformables = append(ao.AgreedPerformables, validConditionalResult)
+		ao.AgreedPerformables = append(ao.AgreedPerformables, newResult)
 		size += newResult.Size()
 	}
 	encoded, err := ao.Encode()

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -57,10 +57,13 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 	for _, result := range obs.Performable {
 		observationSize += result.Size()
 	}
-
+	// TODO: remove this in next version, it's a temporary fix for
+	// supporting old nodes that will limit the number of results rather than the size
+	// of the observation
 	if limit > 0 && len(results) > limit {
 		results = results[:limit]
 	}
+	// add results to observation until size limit is reached
 	added := 0
 	for _, result := range results {
 		observationSize += result.Size()

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -635,12 +635,14 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 				hash := crypto.Keccak256(append(uid[:], triggerExtBytes...))
 				return hex.EncodeToString(hash[:])
 			},
-			RemoveFromStagingHook:  hooks.NewRemoveFromStagingHook(resultStore, logger),
-			RemoveFromMetadataHook: hooks.NewRemoveFromMetadataHook(metadataStore, logger),
-			AddToProposalQHook:     hooks.NewAddToProposalQHook(proposalQueue, logger),
-			AddBlockHistoryHook:    hooks.NewAddBlockHistoryHook(metadataStore, logger),
-			AddFromStagingHook:     hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
-			Logger:                 logger,
+			AddLogProposalsHook:         hooks.NewAddLogProposalsHook(metadataStore, coordinator, logger),
+			AddConditionalProposalsHook: hooks.NewAddConditionalProposalsHook(metadataStore, coordinator, logger),
+			RemoveFromStagingHook:       hooks.NewRemoveFromStagingHook(resultStore, logger),
+			RemoveFromMetadataHook:      hooks.NewRemoveFromMetadataHook(metadataStore, logger),
+			AddToProposalQHook:          hooks.NewAddToProposalQHook(proposalQueue, logger),
+			AddBlockHistoryHook:         hooks.NewAddBlockHistoryHook(metadataStore, logger),
+			AddFromStagingHook:          hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
+			Logger:                      logger,
 		}
 
 		previousOutcome := ocr2keepers2.AutomationOutcome{

--- a/pkg/v3/plugin/performable.go
+++ b/pkg/v3/plugin/performable.go
@@ -83,11 +83,15 @@ func (p *performables) set(outcome *ocr2keepersv3.AutomationOutcome) {
 		return random.ShuffleString(performable[i].WorkID, p.keyRandSource) < random.ShuffleString(performable[j].WorkID, p.keyRandSource)
 	})
 
+	// TODO: remove this in next version, it's a temporary fix for
+	// supporting old nodes that will limit the number of results rather than the size
+	// of the outcome
 	if len(performable) > p.limit {
 		p.logger.Printf("Limiting new performables in outcome to %d", p.limit)
 		performable = performable[:p.limit]
 	}
 
+	// adding performables until size limit is reached
 	size := 0
 	for i, result := range performable {
 		size += result.Size()

--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -165,17 +165,12 @@ type CheckResult struct {
 
 // Size returns the size of the check result in bytes
 func (cr *CheckResult) Size() int {
-	size := 1 + // PipelineExecutionState
+	return 1 + // PipelineExecutionState
 		1 + // Retryable
 		1 + // Eligible
 		1 + // IneligibilityReason
-		32 // UpkeepID
-	// trigger
-	size += 8 + 32
-	if cr.Trigger.LogTriggerExtension != nil {
-		size += 32 + 4 + 32 + 8
-	}
-	return size +
+		32 + // UpkeepID
+		cr.Trigger.Size() +
 		32 + // WorkID
 		8 + // GasAllocated
 		len(cr.PerformData) +

--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -163,6 +163,30 @@ type CheckResult struct {
 	RetryInterval time.Duration
 }
 
+// Size returns the size of the check result in bytes
+func (cr *CheckResult) Size() int {
+	size := 1 + // PipelineExecutionState
+		1 + // Retryable
+		1 + // Eligible
+		1 + // IneligibilityReason
+		32 // UpkeepID
+	// trigger
+	size += 8 + 32
+	if cr.Trigger.LogTriggerExtension != nil {
+		size += 32 + 4 + 32 + 8
+	}
+	size += 32 + // WorkID
+		8 + // GasAllocated
+		len(cr.PerformData)
+	if cr.FastGasWei != nil {
+		size += 32
+	}
+	if cr.LinkNative != nil {
+		size += 32
+	}
+	return size
+}
+
 // checkResultMsg is used for encoding and decoding check results.
 type checkResultMsg struct {
 	PipelineExecutionState uint8

--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -124,16 +124,6 @@ type TransmitEvent struct {
 	CheckBlock BlockNumber
 }
 
-type CheckResults []CheckResult
-
-func (cr CheckResults) Size() int {
-	size := 0
-	for _, r := range cr {
-		size += r.Size()
-	}
-	return size
-}
-
 // NOTE: This struct is sent on the p2p network as part of observations to get quorum
 // Any change here should be backwards compatible and should keep validation and
 // quorum requirements in mind. Any field that is needed to be encoded should be added
@@ -185,16 +175,12 @@ func (cr *CheckResult) Size() int {
 	if cr.Trigger.LogTriggerExtension != nil {
 		size += 32 + 4 + 32 + 8
 	}
-	size += 32 + // WorkID
+	return size +
+		32 + // WorkID
 		8 + // GasAllocated
-		len(cr.PerformData)
-	if cr.FastGasWei != nil {
-		size += 32
-	}
-	if cr.LinkNative != nil {
-		size += 32
-	}
-	return size
+		len(cr.PerformData) +
+		32 + // FastGasWei
+		32 // LinkNative
 }
 
 // checkResultMsg is used for encoding and decoding check results.

--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -124,6 +124,16 @@ type TransmitEvent struct {
 	CheckBlock BlockNumber
 }
 
+type CheckResults []CheckResult
+
+func (cr CheckResults) Size() int {
+	size := 0
+	for _, r := range cr {
+		size += r.Size()
+	}
+	return size
+}
+
 // NOTE: This struct is sent on the p2p network as part of observations to get quorum
 // Any change here should be backwards compatible and should keep validation and
 // quorum requirements in mind. Any field that is needed to be encoded should be added
@@ -319,6 +329,11 @@ func (bh BlockHistory) Latest() (BlockKey, error) {
 	return bh[0], nil
 }
 
+// Size returns the size of the block history in bytes
+func (bh BlockHistory) Size() int {
+	return len(bh) * (8 + 32)
+}
+
 type UpkeepPayload struct {
 	// Upkeep is all the information that identifies the upkeep
 	UpkeepID UpkeepIdentifier
@@ -352,6 +367,13 @@ type CoordinatedBlockProposal struct {
 	Trigger Trigger
 	// WorkID represents the unit of work for the coordinated proposal
 	WorkID string
+}
+
+// Size returns the size of the coordinated block proposal in bytes
+func (p CoordinatedBlockProposal) Size() int {
+	return 32 + // UpkeepID
+		p.Trigger.Size() + // Trigger
+		32 // WorkID
 }
 
 // ReportedUpkeep contains details of an upkeep for which a report was generated.

--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -163,19 +163,14 @@ type CheckResult struct {
 	RetryInterval time.Duration
 }
 
-// Size returns the size of the check result in bytes
+// Size returns the size of the check result in bytes.
+// the size includes additional characters added by the JSON encoding
 func (cr *CheckResult) Size() int {
-	return 1 + // PipelineExecutionState
-		1 + // Retryable
-		1 + // Eligible
-		1 + // IneligibilityReason
-		32 + // UpkeepID
-		cr.Trigger.Size() +
-		32 + // WorkID
-		8 + // GasAllocated
-		len(cr.PerformData) +
-		32 + // FastGasWei
-		32 // LinkNative
+	bytes, err := cr.MarshalJSON()
+	if err != nil {
+		return 0
+	}
+	return len(bytes)
 }
 
 // checkResultMsg is used for encoding and decoding check results.
@@ -312,7 +307,11 @@ func (bh BlockHistory) Latest() (BlockKey, error) {
 
 // Size returns the size of the block history in bytes
 func (bh BlockHistory) Size() int {
-	return len(bh) * (8 + 32)
+	bytes, err := json.Marshal(bh)
+	if err != nil {
+		return 0
+	}
+	return len(bytes)
 }
 
 type UpkeepPayload struct {
@@ -352,9 +351,11 @@ type CoordinatedBlockProposal struct {
 
 // Size returns the size of the coordinated block proposal in bytes
 func (p CoordinatedBlockProposal) Size() int {
-	return 32 + // UpkeepID
-		p.Trigger.Size() + // Trigger
-		32 // WorkID
+	bytes, err := json.Marshal(p)
+	if err != nil {
+		return 0
+	}
+	return len(bytes)
 }
 
 // ReportedUpkeep contains details of an upkeep for which a report was generated.

--- a/pkg/v3/types/basetypes_test.go
+++ b/pkg/v3/types/basetypes_test.go
@@ -213,6 +213,158 @@ func TestUpkeepIdentifier_BigInt(t *testing.T) {
 	}
 }
 
+func TestBlockHistory_Size(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BlockHistory
+	}{
+		{
+			name:  "empty block history",
+			input: BlockHistory{},
+		},
+		{
+			name: "with block history",
+			input: BlockHistory{
+				{
+					Number: 1,
+					Hash:   [32]byte{1, 2, 3, 4},
+				},
+				{
+					Number: 2,
+					Hash:   [32]byte{1, 2, 3, 4},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, len(encoded), tc.input.Size())
+		})
+	}
+}
+
+func TestCoordinatedBlockProposal_Size(t *testing.T) {
+	tests := []struct {
+		name  string
+		input CoordinatedBlockProposal
+	}{
+		{
+			name:  "empty proposal",
+			input: CoordinatedBlockProposal{},
+		},
+		{
+			name: "with log trigger",
+			input: CoordinatedBlockProposal{
+				UpkeepID: UpkeepIdentifier{1, 2, 3, 4, 5, 6, 7, 8},
+				Trigger: Trigger{
+					BlockNumber: 5,
+					BlockHash:   [32]byte{1, 2, 3, 4},
+					LogTriggerExtension: &LogTriggerExtension{
+						TxHash: [32]byte{1, 2, 3, 4},
+						Index:  99,
+					},
+				},
+				WorkID: "work id",
+			},
+		},
+		{
+			name: "with condition trigger",
+			input: CoordinatedBlockProposal{
+				UpkeepID: UpkeepIdentifier{1, 2, 3, 4, 5, 6, 7, 8},
+				Trigger: Trigger{
+					BlockNumber: 5,
+					BlockHash:   [32]byte{1, 2, 3, 4},
+				},
+				WorkID: "work id",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, len(encoded), tc.input.Size())
+		})
+	}
+}
+
+func TestCheckResult_Size(t *testing.T) {
+	tests := []struct {
+		name  string
+		input CheckResult
+	}{
+		{
+			name:  "empty result",
+			input: CheckResult{},
+		},
+		{
+			name: "with large perform data",
+			input: CheckResult{
+				PipelineExecutionState: 1,
+				Retryable:              false,
+				Eligible:               true,
+				IneligibilityReason:    10,
+				UpkeepID:               UpkeepIdentifier{1, 2, 3, 4, 5, 6, 7, 8},
+				Trigger: Trigger{
+					BlockNumber: 5,
+					BlockHash:   [32]byte{1, 2, 3, 4},
+					LogTriggerExtension: &LogTriggerExtension{
+						TxHash: [32]byte{1, 2, 3, 4},
+						Index:  99,
+					},
+				},
+				WorkID:       "work id",
+				GasAllocated: 1001,
+				PerformData: func() []byte {
+					data := make([]byte, 1000)
+					for i := range data {
+						data[i] = byte(i)
+					}
+					return data
+				}(),
+				FastGasWei: big.NewInt(12),
+				LinkNative: big.NewInt(13),
+			},
+		},
+		{
+			name: "with retry interval",
+			input: CheckResult{
+				PipelineExecutionState: 1,
+				Retryable:              true,
+				Eligible:               true,
+				IneligibilityReason:    10,
+				UpkeepID:               UpkeepIdentifier{1, 2, 3, 4, 5, 6, 7, 8},
+				Trigger: Trigger{
+					BlockNumber: 5,
+					BlockHash:   [32]byte{1, 2, 3, 4},
+					LogTriggerExtension: &LogTriggerExtension{
+						TxHash: [32]byte{1, 2, 3, 4},
+						Index:  99,
+					},
+				},
+				WorkID:        "work id",
+				GasAllocated:  1001,
+				PerformData:   []byte{1, 2, 3, 4, 5, 6},
+				FastGasWei:    big.NewInt(12),
+				LinkNative:    big.NewInt(13),
+				RetryInterval: 1,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, len(encoded), tc.input.Size())
+		})
+	}
+}
+
 func TestCheckResultEncoding(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/v3/types/trigger.go
+++ b/pkg/v3/types/trigger.go
@@ -23,14 +23,6 @@ type Trigger struct {
 	LogTriggerExtension *LogTriggerExtension
 }
 
-func (r Trigger) Size() int {
-	size := 32 + 8
-	if r.LogTriggerExtension != nil {
-		size += 32 + 4 + 32 + 8
-	}
-	return size
-}
-
 func (r Trigger) String() string {
 	res := fmt.Sprintf(`{"BlockNumber":%d,"BlockHash":"%s"`, r.BlockNumber, hex.EncodeToString(r.BlockHash[:]))
 	if r.LogTriggerExtension != nil {

--- a/pkg/v3/types/trigger.go
+++ b/pkg/v3/types/trigger.go
@@ -23,6 +23,14 @@ type Trigger struct {
 	LogTriggerExtension *LogTriggerExtension
 }
 
+func (r Trigger) Size() int {
+	size := 32 + 8
+	if r.LogTriggerExtension != nil {
+		size += 32 + 4 + 32 + 8
+	}
+	return size
+}
+
 func (r Trigger) String() string {
 	res := fmt.Sprintf(`{"BlockNumber":%d,"BlockHash":"%s"`, r.BlockNumber, hex.EncodeToString(r.BlockHash[:]))
 	if r.LogTriggerExtension != nil {


### PR DESCRIPTION
AUTO-7597

#### Description

The idea is to put the maximal number of performables in observation/outcome dynamically calculate it based on performData and what fits into observation / outcome size, rather than using a fixed limit of number of upkeeps based on hardcoded limits.

#### Changes

* Added helper functions to calculate size
* Limit the amount of performables based on bytes size rather than hardcoded number of results
* Validate performables bytes size rather than hardcoded number of results
* Backwards compatibility (only for generating compatible outcome/observation, validation is being done only on the number of bytes)
  * **NOTE:** a followup PR should reduce backwards compatibility, which will be only for a single version
