### PR TITLE
Adding observation and performable metrics

### DIFF
--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -60,7 +60,6 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 		plugin.RemoveFromMetadataHook.RunHook(automationOutcome)
 		plugin.AddToProposalQHook.RunHook(automationOutcome)
 	}
-
 	// Create new AutomationObservation
 	observation := ocr2keepersv3.AutomationObservation{}
 
@@ -104,7 +103,7 @@ func (plugin *ocr3Plugin) Outcome(outctx ocr3types.OutcomeContext, query ocr2plu
 		observation, err := ocr2keepersv3.DecodeAutomationObservation(attributedObservation.Observation, plugin.UpkeepTypeGetter, plugin.WorkIDGenerator)
 		if err != nil {
 			plugin.Logger.Printf("invalid observation from oracle %d in seqNr %d err %v", attributedObservation.Observer, outctx.SeqNr, err)
-			prommetrics.AutomationPluginError.WithLabelValues(prommetrics.PluginErrorTypeInvalidOracleObservation).Inc()
+			prommetrics.AutomationPluginError.WithLabelValues(prommetrics.PluginStepOutcome, prommetrics.PluginErrorTypeInvalidOracleObservation).Inc()
 			// Ignore this observation and continue with further observations. It is expected we will get
 			// at least f+1 valid observations
 			continue

--- a/pkg/v3/plugin/performable.go
+++ b/pkg/v3/plugin/performable.go
@@ -54,8 +54,7 @@ func (p *performables) add(observation ocr2keepersv3.AutomationObservation) {
 
 		p.resultCount[uid] = payloadCount
 	}
-	newResultCount := len(p.resultCount) - initialCount
-	p.logger.Printf("Added %d new results from %d performables", newResultCount, len(observation.Performable))
+	p.logger.Printf("Added %d new results from %d performables", len(p.resultCount)-initialCount, len(observation.Performable))
 }
 
 func (p *performables) set(outcome *ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/plugin/performable.go
+++ b/pkg/v3/plugin/performable.go
@@ -7,7 +7,6 @@ import (
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/prommetrics"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/random"
 )
 
@@ -57,8 +56,6 @@ func (p *performables) add(observation ocr2keepersv3.AutomationObservation) {
 	}
 	newResultCount := len(p.resultCount) - initialCount
 	p.logger.Printf("Added %d new results from %d performables", newResultCount, len(observation.Performable))
-	prommetrics.AutomationNewResultsAddedFromPerformables.Set(float64(newResultCount))
-	prommetrics.AutomationTotalPerformablesInObservation.Set(float64(len(observation.Performable)))
 }
 
 func (p *performables) set(outcome *ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/plugin/performable.go
+++ b/pkg/v3/plugin/performable.go
@@ -4,9 +4,11 @@ import (
 	"log"
 	"sort"
 
-	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/random"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+
+	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/prommetrics"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/random"
 )
 
 type resultAndCount struct {
@@ -53,7 +55,10 @@ func (p *performables) add(observation ocr2keepersv3.AutomationObservation) {
 
 		p.resultCount[uid] = payloadCount
 	}
-	p.logger.Printf("Added %d new results from %d performables", len(p.resultCount)-initialCount, len(observation.Performable))
+	newResultCount := len(p.resultCount) - initialCount
+	p.logger.Printf("Added %d new results from %d performables", newResultCount, len(observation.Performable))
+	prommetrics.AutomationNewResultsAddedFromPerformables.Set(float64(newResultCount))
+	prommetrics.AutomationTotalPerformablesInObservation.Set(float64(len(observation.Performable)))
 }
 
 func (p *performables) set(outcome *ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/prommetrics/metrics.go
+++ b/pkg/v3/prommetrics/metrics.go
@@ -1,0 +1,33 @@
+package prommetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// AutomationNamespace is the namespace for all Automation related metrics
+const AutomationNamespace = "automation"
+
+// Automation metrics
+var (
+	AutomationNewResultsAddedFromPerformables = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationNamespace,
+		Name:      "new_results_added_from_performables",
+		Help:      "How many results were added from the peformables for a given observation",
+	})
+	AutomationTotalPerformablesInObservation = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationNamespace,
+		Name:      "total_performables_in_observation",
+		Help:      "How many total performables were in the observation",
+	})
+	AutomationErrorInvalidOracleObservation = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: AutomationNamespace,
+		Name:      "error_invalid_oracle_observation",
+		Help:      "Count of how many invalid oracle observations have been made",
+	})
+	AutomationErrorPreviousOutcomeDecode = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: AutomationNamespace,
+		Name:      "error_previous_outcome_decode",
+		Help:      "Count of how many errors were encountered when decoding previous outcome",
+	})
+)

--- a/pkg/v3/prommetrics/metrics.go
+++ b/pkg/v3/prommetrics/metrics.go
@@ -6,28 +6,38 @@ import (
 )
 
 // AutomationNamespace is the namespace for all Automation related metrics
-const AutomationNamespace = "automation"
+const NamespaceAutomation = "automation"
+
+// Plugin error types
+const (
+	PluginErrorTypeInvalidOracleObservation = "invalid_oracle_observation"
+	PluginErrorTypeDecodeOutcome            = "decode_outcome"
+	PluginErrorTypeEncodeReport             = "encode_report"
+)
+
+// Plugin steps
+const (
+	PluginStepResultStore = "result_store"
+	PluginStepObservation = "observation"
+	PluginStepOutcome     = "outcome"
+	PluginStepReports     = "reports"
+)
 
 // Automation metrics
 var (
-	AutomationNewResultsAddedFromPerformables = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: AutomationNamespace,
-		Name:      "new_results_added_from_performables",
-		Help:      "How many results were added from the peformables for a given observation",
+	AutomationPluginPerformables = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: NamespaceAutomation,
+		Name:      "plugin_performables",
+		Help:      "How many performables were present at a given step in the plugin flow",
+	}, []string{
+		"step",
 	})
-	AutomationTotalPerformablesInObservation = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: AutomationNamespace,
-		Name:      "total_performables_in_observation",
-		Help:      "How many total performables were in the observation",
-	})
-	AutomationErrorInvalidOracleObservation = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: AutomationNamespace,
-		Name:      "error_invalid_oracle_observation",
-		Help:      "Count of how many invalid oracle observations have been made",
-	})
-	AutomationErrorPreviousOutcomeDecode = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: AutomationNamespace,
-		Name:      "error_previous_outcome_decode",
-		Help:      "Count of how many errors were encountered when decoding previous outcome",
+	AutomationPluginError = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: NamespaceAutomation,
+		Name:      "plugin_error",
+		Help:      "Count of how many errors were encountered in the plugin by label",
+	}, []string{
+		"step",
+		"error",
 	})
 )

--- a/pkg/v3/prommetrics/metrics.go
+++ b/pkg/v3/prommetrics/metrics.go
@@ -5,7 +5,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// AutomationNamespace is the namespace for all Automation related metrics
+// NamespaceAutomation is the namespace for all Automation related metrics
 const NamespaceAutomation = "automation"
 
 // Plugin error types


### PR DESCRIPTION
This PR adds two metrics to the CLA OCR steps to better track the performance of OCR and any errors:
1. `plugin_performables`
2. `plugin_error`