### PR TITLE
Switch from encoding/json to goccy/go-json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/holiman/uint256 v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/go-echarts/go-echarts/v2 v2.2.6 h1:Gg4SXDxFwi/KzRvBuH6ed89b6bqP4F7ysA
 github.com/go-echarts/go-echarts/v2 v2.2.6/go.mod h1:IN5P8jIRZKENmAJf2lHXBzv8U9YwdVnY9urdzGkEDA0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/pkg/v3/config/config.go
+++ b/pkg/v3/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"encoding/json"
 	"runtime"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/pkg/v3/config/config_test.go
+++ b/pkg/v3/config/config_test.go
@@ -153,7 +153,7 @@ func TestDecodeOffchainConfig(t *testing.T) {
 					}
 				}
 			`),
-			ExpectedErrString: "json: cannot unmarshal string",
+			ExpectedErrString: "json: cannot unmarshal number \" into Go struct field OffchainConfig.PerformLockoutWindow of type int64",
 			ExpectedConfig:    OffchainConfig{},
 		},
 	} {

--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -1,12 +1,11 @@
 package ocr2keepers
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 
+	"github.com/goccy/go-json"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
-
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 )
 

--- a/pkg/v3/outcome.go
+++ b/pkg/v3/outcome.go
@@ -1,9 +1,9 @@
 package ocr2keepers
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/goccy/go-json"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 )

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
 	"log"
@@ -13,8 +12,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/assert"
-
+	"github.com/goccy/go-json"
 	ocr2keepers2 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/plugin/hooks"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
@@ -22,6 +20,7 @@ import (
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocr2plustypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOcr3Plugin_Query(t *testing.T) {
@@ -942,7 +941,7 @@ func TestOcr3Plugin_ValidateObservation(t *testing.T) {
 			name:        "validating an empty observation returns an error",
 			observation: ocr2plustypes.AttributedObservation{},
 			expectsErr:  true,
-			wantErr:     errors.New("unexpected end of JSON input"),
+			wantErr:     errors.New("invalid character '\x00' looking for beginning of value"),
 		},
 		{
 			name: "successfully validates a well formed observation",
@@ -1126,7 +1125,7 @@ func TestOcr3Plugin_Reports(t *testing.T) {
 			sequenceNumber: 5,
 			outcome:        ocr3types.Outcome([]byte{}),
 			expectsErr:     true,
-			wantErr:        errors.New("unexpected end of JSON input"),
+			wantErr:        errors.New("invalid character '\x00' looking for beginning of value"),
 		},
 		{
 			name:                "an empty json object generates a nil report",


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-9387

In this PR, we're switching from `encoding/json` to `goccy/go-json`, a library with [promising benchmarks](https://github.com/goccy/go-json?tab=readme-ov-file#benchmarks) that is `encoding/json` compatible

In terms of acceptance criteria for this change:
- We should expect all tests to pass (node upgrade test too)
- We will hopefully see performance improvements (fewer "Outcome/Reports is taking too long" messages during load tests)

One point worth considering is that the error messages returned by `goccy/go-json` are more specific than those returned by `encoding/json`; as such, we should review the automation code in the plugin and in core, for any instances where we check for a specific error message, and ensure that the same flow is executed when we use `goccy/go-json`

# Testing

For this test, the load test was ran against this branch, and latest develop, multiple times. In each set of test runs, the shape of the log volumes reported in grafana was the same.

## "Taking too long" logs

Based on the logs we see in grafana, and given the same load test scenario (500 upkeeps over one hour), it looks as though there has been a decrease in the number of "taking too long" logs overall.

### Before 

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/feeedb24-9a30-46d4-b69b-52db2f1fce5e">

### After 

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/2aeb98fe-06c0-4f57-8966-067e149b5718">

## "Observation is taking too long" logs

Observations taking too long still happens, with only a slight reduction in occurrences of long observations

### Before

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/1d625830-1593-42f7-8cdc-9463baa9eadd">

### After 

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/83041534-11a7-415c-917f-18f3ea717ec7">

## "Outcome is taking too long" logs

This is the most significant improvement we've gained with this change (note the Y axis)

### Before

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/6a28d832-9234-4863-91e0-01c493d70ae4">

### After 

<img width="1406" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/6a91617e-f952-41a0-94ba-5e564f44f11e">

## Integration tests

Integration tests are passing for this change as per this draft PR: https://github.com/smartcontractkit/chainlink/pull/12755

## Node upgrade tests

Node upgrade tests are passing for this change as per this CI run: https://github.com/smartcontractkit/chainlink/actions/runs/8880827638

## Summary

It looks as though this change does give us some benefit, especially for outcomes, though it looks like there are other causes of observations taking too long, unrelated to JSON encoding/decoding