### PR TITLE
Spike: Dynamic performables on observation

### DIFF
--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -1,9 +1,11 @@
 package ocr2keepers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 
@@ -47,6 +49,276 @@ func (observation AutomationObservation) Encode() ([]byte, error) {
 	return json.Marshal(observation)
 }
 
+func (observation AutomationObservation) Length() int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+	nullFieldChars := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+	performablesNameAndQuotes := 13
+	upkeepProposalsNameAndQuotes := 17
+	blockHistoryNameAndQuotes := 14
+
+	fieldValues := 0
+	if observation.Performable == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += performablesLength(observation.Performable)
+	}
+
+	if observation.UpkeepProposals == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += upkeepProposalsLength(observation.UpkeepProposals)
+	}
+
+	if observation.BlockHistory == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += blockHistoryLength(observation.BlockHistory)
+	}
+
+	return objectBraces + fieldSeparators + numberOfColons + performablesNameAndQuotes + upkeepProposalsNameAndQuotes + blockHistoryNameAndQuotes + fieldValues
+}
+
+func performablesLength(results []ocr2keepers.CheckResult) int {
+	if len(results) == 0 {
+		return 2
+	} else {
+		performablesLength := 0
+
+		numberOfFields := len(results) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, result := range results {
+			performablesLength += performableLength(result)
+		}
+
+		return objectBraces + fieldSeparators + performablesLength
+	}
+}
+
+func performableLength(result ocr2keepers.CheckResult) int {
+	numberOfFields := 11 // should not be counted, used to coordinate values, we don't include retry interval
+	nullFieldChars := 4  // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	pipelineExecutionStateNameAndQuotes := 24
+	retryablenameAndQuotes := 11
+	eligibleNameAndQuotes := 10
+	ineligibilityReasonNameAndQuotes := 21
+	upkeepIDNameAndQuotes := 10
+	triggerNameAndQuotes := 9
+	workIDNameAndQuotes := 8
+	gasAllocatedNameAndQuotes := 14
+	performDataNameAndQuotes := 13
+	fastGasWeiNameAndQuotes := 12
+	linkNativeNameAndQuotes := 12
+
+	valueSizes := 0
+	valueSizes += uint8Length(result.PipelineExecutionState)
+	valueSizes += boolLength(result.Retryable)
+	valueSizes += boolLength(result.Eligible)
+	valueSizes += uint8Length(result.IneligibilityReason)
+	valueSizes += 2 + byte32Length(result.UpkeepID) + len(result.UpkeepID) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	valueSizes += triggerLength(result.Trigger)
+
+	valueSizes += 2 + len(result.WorkID)
+	valueSizes += uint64Length(result.GasAllocated)
+
+	if result.PerformData == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += 2 + len(hex.EncodeToString(result.PerformData))
+	}
+
+	if result.FastGasWei == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += len(result.FastGasWei.String()) // quotes aren't included in big int json
+	}
+
+	if result.LinkNative == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += len(result.LinkNative.String()) // quotes aren't included in big int json
+	}
+
+	return objectBraces + numberOfColons + fieldSeparators + pipelineExecutionStateNameAndQuotes + retryablenameAndQuotes +
+		eligibleNameAndQuotes + ineligibilityReasonNameAndQuotes + upkeepIDNameAndQuotes + triggerNameAndQuotes + workIDNameAndQuotes +
+		gasAllocatedNameAndQuotes + performDataNameAndQuotes + fastGasWeiNameAndQuotes + linkNativeNameAndQuotes + valueSizes
+}
+
+func triggerLength(t ocr2keepers.Trigger) int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+	nullFieldChars := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	blockNumberNameAndQuotes := 13
+	blockHashNameAndQuotes := 11
+	logTriggerExtensionNameAndQuotes := 21
+
+	valueSizes := 0
+
+	valueSizes += uint64Length(uint64(t.BlockNumber))
+	valueSizes += 2 + byte32Length(t.BlockHash) + len(t.BlockHash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	if t.LogTriggerExtension == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += logTriggerExtensionLength(t.LogTriggerExtension)
+	}
+
+	return objectBraces + numberOfColons + fieldSeparators + blockNumberNameAndQuotes + blockHashNameAndQuotes + logTriggerExtensionNameAndQuotes + valueSizes
+}
+
+func logTriggerExtensionLength(extension *ocr2keepers.LogTriggerExtension) int {
+	numberOfFields := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	txHashNameAndQuotes := 8
+	indexNameAndQuotes := 7
+	blockHashNameAndQuotes := 11
+	blockNumberNameAndQuotes := 13
+
+	valueSizes := 0
+
+	valueSizes += 2 + byte32Length(extension.TxHash) + len(extension.TxHash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+	valueSizes += uint32Length(extension.Index)
+	valueSizes += uint64Length(uint64(extension.BlockNumber))
+	valueSizes += 2 + byte32Length(extension.BlockHash) + len(extension.BlockHash) - 1 /// 2 for brackets, length of bytes, length-1 for commas
+
+	return objectBraces + numberOfColons + fieldSeparators + txHashNameAndQuotes + indexNameAndQuotes + blockNumberNameAndQuotes + blockHashNameAndQuotes + valueSizes
+
+}
+
+func byteSliceLength(b []byte) int {
+	len := 0
+
+	for _, x := range b {
+		len += uint8Length(x)
+	}
+
+	return len
+}
+
+func byte32Length(b [32]byte) int {
+	return byteSliceLength(b[:])
+}
+
+func uint64Length(i uint64) int {
+	return len(strconv.FormatUint(i, 10))
+}
+
+func uint32Length(i uint32) int {
+	return len(strconv.FormatUint(uint64(i), 10))
+}
+
+func uint8Length(i uint8) int {
+	if i < 10 {
+		return 1
+	} else if i < 100 {
+		return 2
+	}
+	return 3
+}
+
+func boolLength(b bool) int {
+	if b {
+		return 4
+	}
+	return 5
+}
+
+func upkeepProposalsLength(proposals []ocr2keepers.CoordinatedBlockProposal) int {
+	if len(proposals) == 0 {
+		return 2
+	} else {
+		proposalsLength := 0
+
+		numberOfFields := len(proposals) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, proposal := range proposals {
+			proposalsLength += proposalLength(proposal)
+		}
+
+		return objectBraces + fieldSeparators + proposalsLength
+	}
+}
+
+func proposalLength(proposal ocr2keepers.CoordinatedBlockProposal) int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	upkeepIDNameAndQuotes := 10
+	triggerNameAndQuotes := 9
+	workIDNameAndQuotes := 8
+
+	valueSizes := 0
+
+	valueSizes += 2 + byte32Length(proposal.UpkeepID) + len(proposal.UpkeepID) - 1 // 2 for brackets, length of bytes, length-1 for commas
+	valueSizes += triggerLength(proposal.Trigger)
+	valueSizes += 2 + len(proposal.WorkID)
+
+	return objectBraces + numberOfColons + fieldSeparators + upkeepIDNameAndQuotes + triggerNameAndQuotes + workIDNameAndQuotes + valueSizes
+}
+
+func blockHistoryLength(blockHistory ocr2keepers.BlockHistory) int {
+	if len(blockHistory) == 0 {
+		return 2
+	} else {
+		blockHistoryLength := 0
+
+		numberOfFields := len(blockHistory) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, block := range blockHistory {
+			blockHistoryLength += blockLength(block)
+		}
+
+		return objectBraces + fieldSeparators + blockHistoryLength
+	}
+}
+
+func blockLength(key ocr2keepers.BlockKey) int {
+	numberOfFields := 2 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	numberNameAndQuotes := 8
+	hashNameAndQuotes := 6
+
+	valueSizes := 0
+
+	valueSizes += uint64Length(uint64(key.Number))
+	valueSizes += 2 + byte32Length(key.Hash) + len(key.Hash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	return objectBraces + numberOfColons + fieldSeparators + numberNameAndQuotes + hashNameAndQuotes + valueSizes
+}
+
 func DecodeAutomationObservation(data []byte, utg types.UpkeepTypeGetter, wg types.WorkIDGenerator) (AutomationObservation, error) {
 	ao := AutomationObservation{}
 	err := json.Unmarshal(data, &ao)
@@ -74,10 +346,6 @@ func validateAutomationObservation(o AutomationObservation, utg types.UpkeepType
 		seen[uint64(block.Number)] = true
 	}
 
-	// Validate Performables
-	if (len(o.Performable)) > ObservationPerformablesLimit {
-		return fmt.Errorf("performable length cannot be greater than %d", ObservationPerformablesLimit)
-	}
 	seenPerformables := make(map[string]bool)
 	for _, res := range o.Performable {
 		if err := validateCheckResult(res, utg, wg); err != nil {

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -3,6 +3,7 @@ package ocr2keepers
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"os"
 	"testing"
@@ -610,6 +611,315 @@ func TestLargeObservationSize(t *testing.T) {
 
 	assert.Equal(t, ao, decoded, "final result from encoding and decoding should match")
 	assert.Less(t, len(encoded), MaxObservationLength, "encoded observation should be less than maxObservationSize")
+}
+
+func TestObservationLength(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		observation  AutomationObservation
+		expectedJSON string
+		expectedSize int
+	}{
+		{
+			name:         "Empty observation has 63 bytes of JSON",
+			observation:  AutomationObservation{},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":null,"BlockHistory":null}`,
+			expectedSize: 63,
+		},
+		{
+			name: "With non-nil performables, 61 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{},
+			},
+			expectedJSON: `{"Performable":[],"UpkeepProposals":null,"BlockHistory":null}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil upkeep proposals, 61 bytes of JSON",
+			observation: AutomationObservation{
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+			},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":[],"BlockHistory":null}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil block history, 61 bytes of JSON",
+			observation: AutomationObservation{
+				BlockHistory: commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":null,"BlockHistory":[]}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil performable, upkeep proposals and block history, 57 bytes of JSON",
+			observation: AutomationObservation{
+				Performable:     []commontypes.CheckResult{},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 57,
+		},
+		{
+			name: "With one empty performable, upkeep proposals and block history, 438 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 438,
+		},
+		{
+			name: "With two empty performables, empty upkeep proposals and block history, 820 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{},
+					{},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null},{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 820,
+		},
+		{
+			name: "With one partially populated performable, empty upkeep proposals and block history, 473 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":null},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 473,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and block history, 684 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{1, 2, 3, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"AQIDBA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 684,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and block history, 692 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 692,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and non empty block history, 955 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory: commontypes.BlockHistory{
+					commontypes.BlockKey{
+						Number: 1,
+						Hash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 2,
+						Hash:   [32]byte{2, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 3,
+						Hash:   [32]byte{3, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+				},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[{"Number":1,"Hash":[1,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":2,"Hash":[2,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":3,"Hash":[3,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]}]}`,
+			expectedSize: 955,
+		},
+		{
+			name: "With one fully populated performable, upkeep proposals and block history, 2283 bytes of JSON",
+			observation: AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID: "WorkID1",
+					},
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 202003244343430,
+							BlockHash:   [32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{22, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 202003244343430,
+							},
+						},
+						WorkID: "WorkID2",
+					},
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 302003244343430,
+							BlockHash:   [32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{33, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 302003244343430,
+							},
+						},
+						WorkID: "WorkID3",
+					},
+				},
+				BlockHistory: commontypes.BlockHistory{
+					commontypes.BlockKey{
+						Number: 1,
+						Hash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 2,
+						Hash:   [32]byte{2, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 3,
+						Hash:   [32]byte{3, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+				},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[{"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"WorkID1"},{"UpkeepID":[22,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":202003244343430,"BlockHash":[22,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[22,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[22,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":202003244343430}},"WorkID":"WorkID2"},{"UpkeepID":[33,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":302003244343430,"BlockHash":[33,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[33,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[33,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":302003244343430}},"WorkID":"WorkID3"}],"BlockHistory":[{"Number":1,"Hash":[1,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":2,"Hash":[2,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":3,"Hash":[3,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]}]}`,
+			expectedSize: 2283,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.observation)
+			assert.NoError(t, err)
+			assert.Equal(t, len(b), tc.observation.Length())
+			assert.Equal(t, tc.expectedJSON, string(b))
+			assert.Equal(t, tc.expectedSize, len(b))
+		})
+
+	}
 }
 
 func mockUpkeepTypeGetter(id commontypes.UpkeepIdentifier) types.UpkeepType {

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -50,7 +51,7 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 
 	results = hook.sorter.orderResults(results, rSrc)
 
-	count := hook.addByEstimates(obs, results)
+	count := hook.addByEstimatesAggressive(obs, results)
 
 	hook.logger.Printf("adding %d results to observation", count)
 
@@ -71,6 +72,60 @@ func (hook *AddFromStagingHook) addByEstimates(obs *ocr2keepersv3.AutomationObse
 			obs.Performable = obs.Performable[:len(obs.Performable)-1]
 			added--
 			break
+		}
+	}
+
+	return added
+}
+
+func (hook *AddFromStagingHook) addByEstimatesAggressive(obs *ocr2keepersv3.AutomationObservation, results []automation.CheckResult) int {
+	added := 0
+	i := 0
+	for ; i < len(results); i++ {
+		result := results[i]
+		obs.Performable = append(obs.Performable, result)
+		added++
+
+		if obs.Length() > ocr2keepersv3.MaxObservationLength {
+			obs.Performable = obs.Performable[:len(obs.Performable)-1]
+			added--
+			break
+		}
+	}
+
+	// At this point, we've only compared raw json with the max observation length.
+	// We want to try and squeeze as much space as we can out of the observation length limit,
+	// so we try to estimate how many more performables we can add, and after adding all the
+	// additional performables, we marshal the observation and compare the observation
+	// length in bytes with the max observation length. If the serialized observation is above the limit,
+	// we repeatedely remove performables one at a time, and marshal the observation, until the length
+	// of the observation is under the limit.
+	if added > 0 {
+		b, _ := json.Marshal(obs)
+
+		// determine how much space we have left within the max observation length
+		bytesRemaining := ocr2keepersv3.MaxObservationLength - len(b)
+
+		// determine roughly how many bytes each performable has taken up so far
+		bytesPerPerformable := len(b) / added
+
+		// based on the average performable byte size, and the remaining space within the observation
+		// length limit, calculate the number of records we think we can add
+		recordsToAdd := bytesRemaining / bytesPerPerformable
+
+		// add more performables to the observation, continuing where the original add operation left off
+		for recordsAdded := 0; recordsAdded < recordsToAdd && i < len(results); recordsAdded++ {
+			obs.Performable = append(obs.Performable, results[i])
+			added++
+			i++
+		}
+
+		// now, marshal the observation again, check if we've exceeded the observation length, and if we have,
+		// remove one performable from the observation, and repeat until the serialized observation is under the
+		// max observation length
+		for b, _ := json.Marshal(obs); len(b) > ocr2keepersv3.MaxObservationLength; b, _ = json.Marshal(obs) {
+			obs.Performable = obs.Performable[:len(obs.Performable)-1]
+			added--
 		}
 	}
 

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -369,6 +369,9 @@ func BenchmarkAddByJSON(b *testing.B) {
 	results := buildResults(1000)
 	var hook AddFromStagingHook
 	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		hook.addByJSON(observation, results)
 	}
@@ -376,12 +379,19 @@ func BenchmarkAddByJSON(b *testing.B) {
 	// ~2073702875 ns/op
 	// ~1509738375 ns/op
 	// ~1503371541 ns/op
+	// ~1781547625 ns/op
+	// ~1520777792 ns/op
+	// ~1504579084 ns/op
+	// ~1503110916 ns/op
 }
 
 func BenchmarkAddByEstimate(b *testing.B) {
 	results := buildResults(1000)
 	var hook AddFromStagingHook
 	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		hook.addByEstimates(observation, results)
 	}
@@ -389,6 +399,28 @@ func BenchmarkAddByEstimate(b *testing.B) {
 	// ~1352813 ns/op
 	// ~1354153 ns/op
 	// ~902008 ns/op
+	// ~708801 ns/op
+	// ~702047 ns/op
+	// ~699450 ns/op
+	// ~698151 ns/op
+}
+
+func BenchmarkAddByEstimateAggressive(b *testing.B) {
+	results := buildResults(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByEstimatesAggressive(observation, results)
+	}
+
+	// ~883453 ns/op
+	// ~878189 ns/op
+	// ~876328 ns/op
+	// ~889295 ns/op
+	// ~927411 ns/op
 }
 
 func TestAddByJSON(t *testing.T) {
@@ -417,6 +449,116 @@ func TestAddByEstimate(t *testing.T) {
 	assert.Equal(t, len(b), 812164)
 }
 
+func TestAddByEstimateAggressive(t *testing.T) {
+	results := buildResults(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+	added := hook.addByEstimatesAggressive(observation, results)
+	assert.Equal(t, 552, added)
+
+	b, err := observation.Encode()
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+	assert.Equal(t, len(b), 998500)
+}
+
+func BenchmarkAddByJSON_MaxPerformData(b *testing.B) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByJSON(observation, results)
+	}
+
+	// ~2073702875 ns/op
+	// ~1509738375 ns/op
+	// ~1503371541 ns/op
+	// ~1781547625 ns/op
+	// ~1520777792 ns/op
+	// ~4130123 ns/op
+	// ~4104388 ns/op
+}
+
+func BenchmarkAddByEstimate_MaxPerformData(b *testing.B) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByEstimates(observation, results)
+	}
+
+	// ~1352813 ns/op
+	// ~1354153 ns/op
+	// ~902008 ns/op
+	// ~708801 ns/op
+	// ~702047 ns/op
+	// ~560784 ns/op
+	// ~573300 ns/op
+}
+
+func BenchmarkAddByEstimateAggressive_MaxPerformData(b *testing.B) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByEstimatesAggressive(observation, results)
+	}
+
+	// ~883453 ns/op
+	// ~878189 ns/op
+	// ~876328 ns/op
+	// ~816474 ns/op
+	// ~831004 ns/op
+}
+
+func TestAddByJSON_MaxPerformData(t *testing.T) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+	added := hook.addByJSON(observation, results)
+	assert.Equal(t, 69, added)
+
+	b, err := observation.Encode()
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+	assert.Equal(t, len(b), 987278)
+}
+
+func TestAddByEstimate_MaxPerformData(t *testing.T) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+	added := hook.addByEstimates(observation, results)
+	assert.Equal(t, 47, added)
+
+	b, err := observation.Encode()
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+	assert.Equal(t, len(b), 672513)
+}
+
+func TestAddByEstimateAggressive_MaxPerformData(t *testing.T) {
+	results := buildResultsMaxPerformData(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+	added := hook.addByEstimatesAggressive(observation, results)
+	assert.Equal(t, 69, added)
+
+	b, err := observation.Encode()
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+	assert.Equal(t, len(b), 987278)
+}
+
 func buildResults(num int) []types.CheckResult {
 	var res []types.CheckResult
 
@@ -434,10 +576,10 @@ func buildResults(num int) []types.CheckResult {
 			eligible = true
 		}
 
-		length := int(rng.Next())%9501 + 500
-		byteArray := make([]byte, length)
+		length := int(rng.Next())%9501 + 500 // generate random perform data between 500 and 10000 bytes
+		performData := make([]byte, length)
 		for i := 0; i < length; i++ {
-			byteArray[i] = rng.Next()
+			performData[i] = rng.Next()
 		}
 
 		bigNumber := big.NewInt(1844674407370955161)
@@ -460,7 +602,58 @@ func buildResults(num int) []types.CheckResult {
 			},
 			WorkID:       "acd4ff368edb8ab06d3c766b2ff1791ae277aa8efc5357729b640c432f706c86",
 			GasAllocated: bigNumber.Uint64(),
-			PerformData:  byteArray,
+			PerformData:  performData,
+			FastGasWei:   bigNumber,
+			LinkNative:   bigNumber,
+		})
+	}
+
+	return res
+}
+
+func buildResultsMaxPerformData(num int) []types.CheckResult {
+	var res []types.CheckResult
+
+	for i := 0; i < num; i++ {
+		seed := uint32(i)
+		rng := NewDRNG(seed)
+
+		ui := rng.Next()
+
+		retryable, eligible := false, false
+		if ui%1 == 0 {
+			retryable = true
+		}
+		if ui%2 == 0 {
+			eligible = true
+		}
+
+		performData := make([]byte, 10000)
+		for i := 0; i < 10000; i++ {
+			performData[i] = 255
+		}
+
+		bigNumber := big.NewInt(1844674407370955161)
+
+		res = append(res, types.CheckResult{
+			PipelineExecutionState: 255,
+			Retryable:              retryable,
+			Eligible:               eligible,
+			IneligibilityReason:    255,
+			UpkeepID:               [32]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+			Trigger: types.Trigger{
+				BlockNumber: types.BlockNumber(bigNumber.Uint64()),
+				BlockHash:   [32]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+				LogTriggerExtension: &types.LogTriggerExtension{
+					TxHash:      [32]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					Index:       4294967295,
+					BlockHash:   [32]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					BlockNumber: types.BlockNumber(bigNumber.Uint64()),
+				},
+			},
+			WorkID:       "acd4ff368edb8ab06d3c766b2ff1791ae277aa8efc5357729b640c432f706c86",
+			GasAllocated: bigNumber.Uint64(),
+			PerformData:  performData,
 			FastGasWei:   bigNumber,
 			LinkNative:   bigNumber,
 		})

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -69,7 +69,7 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 	// high randomness results in expesive ordering, therefore we reduce
 	// the range of the randomness by dividing the seq number by 10
 	randSrcSeq := outctx.SeqNr / 10
-	if err := plugin.AddFromStagingHook.RunHook(&observation, ocr2keepersv3.ObservationPerformablesLimit, getRandomKeySource(plugin.ConfigDigest, randSrcSeq)); err != nil {
+	if err := plugin.AddFromStagingHook.RunHook(&observation, getRandomKeySource(plugin.ConfigDigest, randSrcSeq)); err != nil {
 		return nil, err
 	}
 	prommetrics.AutomationPluginPerformables.WithLabelValues(prommetrics.PluginStepResultStore).Set(float64(len(observation.Performable)))


### PR DESCRIPTION
In this PR, we're increasing the number of performables that can be added to the observation, based on remaining capacity within the encoded observation.

## Testing

### Load tests

When running the load tests, we sometimes see as many as 225 performables being added to the observation:

<img width="1495" alt="image" src="https://github.com/smartcontractkit/chainlink-automation/assets/19188060/fc9250d0-7e2b-420a-b7dd-fd79e47418b1">
