### PR TITLE
Dynamically add performables to the observation until MaxObservationLength is exceeded

### DIFF
--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -13,7 +13,7 @@ import (
 // as different nodes would upgrade at different times and would need to
 // adhere to each others' limits
 const (
-	ObservationPerformablesLimit          = 50
+	ObservationPerformablesLimit          = 100
 	ObservationLogRecoveryProposalsLimit  = 5
 	ObservationConditionalsProposalsLimit = 5
 	ObservationBlockHistoryLimit          = 256

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -577,7 +577,7 @@ func TestLargeObservationSize(t *testing.T) {
 		})
 	}
 	largePerformData := [10001]byte{}
-	for i := 0; i < ObservationPerformablesLimit; i++ {
+	for i := 0; i < 67; i++ {
 		newResult := validLogResult
 		uid := commontypes.UpkeepIdentifier{}
 		uid.FromBigInt(big.NewInt(int64(i + 10001)))

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -577,7 +577,7 @@ func TestLargeObservationSize(t *testing.T) {
 		})
 	}
 	largePerformData := [10001]byte{}
-	for i := 0; i < 67; i++ {
+	for i := 0; i < ObservationPerformablesLimit; i++ {
 		newResult := validLogResult
 		uid := commontypes.UpkeepIdentifier{}
 		uid.FromBigInt(big.NewInt(int64(i + 10001)))
@@ -609,7 +609,7 @@ func TestLargeObservationSize(t *testing.T) {
 	assert.NoError(t, err, "no error in decoding valid automation observation")
 
 	assert.Equal(t, ao, decoded, "final result from encoding and decoding should match")
-	assert.Less(t, len(encoded), MaxObservationLength, "encoded observation should be less than maxObservationSize")
+	assert.Greaterf(t, len(encoded), MaxObservationLength, "encoded observation will exceed maxObservationSize")
 }
 
 func mockUpkeepTypeGetter(id commontypes.UpkeepIdentifier) types.UpkeepType {

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -490,15 +490,7 @@ func buildResults(num int) []types.CheckResult {
 		seed := uint32(i)
 		rng := NewDRNG(seed)
 
-		ui := rng.Next()
-
-		retryable, eligible := false, false
-		if ui%1 == 0 {
-			retryable = true
-		}
-		if ui%2 == 0 {
-			eligible = true
-		}
+		retryable, eligible := false, true
 
 		length := int(rng.Next())%9501 + 500 // generate random perform data between 500 and 10000 bytes
 		performData := make([]byte, length)
@@ -539,18 +531,7 @@ func buildResultsMaxPerformData(num int) []types.CheckResult {
 	var res []types.CheckResult
 
 	for i := 0; i < num; i++ {
-		seed := uint32(i)
-		rng := NewDRNG(seed)
-
-		ui := rng.Next()
-
-		retryable, eligible := false, false
-		if ui%1 == 0 {
-			retryable = true
-		}
-		if ui%2 == 0 {
-			eligible = true
-		}
+		retryable, eligible := true, false
 
 		performData := make([]byte, 10000)
 		for i := 0; i < 10000; i++ {

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -415,6 +415,72 @@ func TestAddByEstimate(t *testing.T) {
 		assert.Equal(t, len(b), 690346)
 	})
 
+	t.Run("Add as many randomly populated performables until we run out of capacity", func(t *testing.T) {
+		results := buildResults(1000)
+
+		added := hook.addByEstimatesAggressive(observation, results)
+		assert.Equal(t, 521, added)
+
+		b, err := observation.Encode()
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+		assert.Equal(t, len(b), 989272)
+	})
+
+	t.Run("Add as many heavily populated performables until we run out of capacity", func(t *testing.T) {
+		results := buildResultsMaxPerformData(1000)
+
+		added := hook.addByEstimatesAggressive(observation, results)
+		assert.Equal(t, 65, added)
+
+		b, err := observation.Encode()
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, len(b), ocr2keepersv3.MaxObservationLength)
+		assert.Equal(t, len(b), 976496)
+	})
+
+}
+
+func BenchmarkAddByJSON(b *testing.B) {
+	results := buildResults(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByJSON(observation, results)
+	}
+
+	// ~1315313291 ns/op
+}
+
+func BenchmarkAddByEstimate(b *testing.B) {
+	results := buildResults(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByEstimates(observation, 100, results)
+	}
+
+	// ~768741 ns/op
+}
+
+func BenchmarkAddByEstimateAggressive(b *testing.B) {
+	results := buildResults(1000)
+	var hook AddFromStagingHook
+	observation := &ocr2keepersv3.AutomationObservation{}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hook.addByEstimatesAggressive(observation, results)
+	}
+
+	// ~876293 ns/op
 }
 
 func buildResults(num int) []types.CheckResult {

--- a/pkg/v3/plugin/hooks/estimates/json.go
+++ b/pkg/v3/plugin/hooks/estimates/json.go
@@ -1,0 +1,279 @@
+package estimates
+
+import (
+	"encoding/hex"
+	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"strconv"
+)
+
+func ObservationLength(observation *ocr2keepers.AutomationObservation) int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+	nullFieldChars := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	performablesNameAndQuotes := 13
+	upkeepProposalsNameAndQuotes := 17
+	blockHistoryNameAndQuotes := 14
+
+	fieldValues := 0
+	if observation.Performable == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += performablesLength(observation.Performable)
+	}
+
+	if observation.UpkeepProposals == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += upkeepProposalsLength(observation.UpkeepProposals)
+	}
+
+	if observation.BlockHistory == nil {
+		fieldValues += nullFieldChars
+	} else {
+		fieldValues += blockHistoryLength(observation.BlockHistory)
+	}
+
+	return objectBraces + fieldSeparators + numberOfColons + performablesNameAndQuotes + upkeepProposalsNameAndQuotes + blockHistoryNameAndQuotes + fieldValues
+}
+
+func performablesLength(results []automation.CheckResult) int {
+	if len(results) == 0 {
+		return 2
+	} else {
+		performablesLength := 0
+
+		numberOfFields := len(results) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, result := range results {
+			performablesLength += performableLength(result)
+		}
+
+		return objectBraces + fieldSeparators + performablesLength
+	}
+}
+
+func performableLength(result automation.CheckResult) int {
+	numberOfFields := 11 // should not be counted, used to coordinate values, we don't include retry interval
+	nullFieldChars := 4  // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	pipelineExecutionStateNameAndQuotes := 24
+	retryablenameAndQuotes := 11
+	eligibleNameAndQuotes := 10
+	ineligibilityReasonNameAndQuotes := 21
+	upkeepIDNameAndQuotes := 10
+	triggerNameAndQuotes := 9
+	workIDNameAndQuotes := 8
+	gasAllocatedNameAndQuotes := 14
+	performDataNameAndQuotes := 13
+	fastGasWeiNameAndQuotes := 12
+	linkNativeNameAndQuotes := 12
+
+	valueSizes := 0
+	valueSizes += uint8Length(result.PipelineExecutionState)
+	valueSizes += boolLength(result.Retryable)
+	valueSizes += boolLength(result.Eligible)
+	valueSizes += uint8Length(result.IneligibilityReason)
+	valueSizes += 2 + byte32Length(result.UpkeepID) + len(result.UpkeepID) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	valueSizes += triggerLength(result.Trigger)
+
+	valueSizes += 2 + len(result.WorkID)
+	valueSizes += uint64Length(result.GasAllocated)
+
+	if result.PerformData == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += 2 + len(hex.EncodeToString(result.PerformData))
+	}
+
+	if result.FastGasWei == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += len(result.FastGasWei.String()) // quotes aren't included in big int json
+	}
+
+	if result.LinkNative == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += len(result.LinkNative.String()) // quotes aren't included in big int json
+	}
+
+	return objectBraces + numberOfColons + fieldSeparators + pipelineExecutionStateNameAndQuotes + retryablenameAndQuotes +
+		eligibleNameAndQuotes + ineligibilityReasonNameAndQuotes + upkeepIDNameAndQuotes + triggerNameAndQuotes + workIDNameAndQuotes +
+		gasAllocatedNameAndQuotes + performDataNameAndQuotes + fastGasWeiNameAndQuotes + linkNativeNameAndQuotes + valueSizes
+}
+
+func triggerLength(t automation.Trigger) int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+	nullFieldChars := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	blockNumberNameAndQuotes := 13
+	blockHashNameAndQuotes := 11
+	logTriggerExtensionNameAndQuotes := 21
+
+	valueSizes := 0
+
+	valueSizes += uint64Length(uint64(t.BlockNumber))
+	valueSizes += 2 + byte32Length(t.BlockHash) + len(t.BlockHash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	if t.LogTriggerExtension == nil {
+		valueSizes += nullFieldChars
+	} else {
+		valueSizes += logTriggerExtensionLength(t.LogTriggerExtension)
+	}
+
+	return objectBraces + numberOfColons + fieldSeparators + blockNumberNameAndQuotes + blockHashNameAndQuotes + logTriggerExtensionNameAndQuotes + valueSizes
+}
+
+func logTriggerExtensionLength(extension *automation.LogTriggerExtension) int {
+	numberOfFields := 4 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	txHashNameAndQuotes := 8
+	indexNameAndQuotes := 7
+	blockHashNameAndQuotes := 11
+	blockNumberNameAndQuotes := 13
+
+	valueSizes := 0
+
+	valueSizes += 2 + byte32Length(extension.TxHash) + len(extension.TxHash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+	valueSizes += uint32Length(extension.Index)
+	valueSizes += uint64Length(uint64(extension.BlockNumber))
+	valueSizes += 2 + byte32Length(extension.BlockHash) + len(extension.BlockHash) - 1 /// 2 for brackets, length of bytes, length-1 for commas
+
+	return objectBraces + numberOfColons + fieldSeparators + txHashNameAndQuotes + indexNameAndQuotes + blockNumberNameAndQuotes + blockHashNameAndQuotes + valueSizes
+
+}
+
+func byteSliceLength(b []byte) int {
+	len := 0
+
+	for _, x := range b {
+		len += uint8Length(x)
+	}
+
+	return len
+}
+
+func byte32Length(b [32]byte) int {
+	return byteSliceLength(b[:])
+}
+
+func uint64Length(i uint64) int {
+	return len(strconv.FormatUint(i, 10))
+}
+
+func uint32Length(i uint32) int {
+	return len(strconv.FormatUint(uint64(i), 10))
+}
+
+func uint8Length(i uint8) int {
+	if i < 10 {
+		return 1
+	} else if i < 100 {
+		return 2
+	}
+	return 3
+}
+
+func boolLength(b bool) int {
+	if b {
+		return 4
+	}
+	return 5
+}
+
+func upkeepProposalsLength(proposals []automation.CoordinatedBlockProposal) int {
+	if len(proposals) == 0 {
+		return 2
+	} else {
+		proposalsLength := 0
+
+		numberOfFields := len(proposals) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, proposal := range proposals {
+			proposalsLength += proposalLength(proposal)
+		}
+
+		return objectBraces + fieldSeparators + proposalsLength
+	}
+}
+
+func proposalLength(proposal automation.CoordinatedBlockProposal) int {
+	numberOfFields := 3 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	upkeepIDNameAndQuotes := 10
+	triggerNameAndQuotes := 9
+	workIDNameAndQuotes := 8
+
+	valueSizes := 0
+
+	valueSizes += 2 + byte32Length(proposal.UpkeepID) + len(proposal.UpkeepID) - 1 // 2 for brackets, length of bytes, length-1 for commas
+	valueSizes += triggerLength(proposal.Trigger)
+	valueSizes += 2 + len(proposal.WorkID)
+
+	return objectBraces + numberOfColons + fieldSeparators + upkeepIDNameAndQuotes + triggerNameAndQuotes + workIDNameAndQuotes + valueSizes
+}
+
+func blockHistoryLength(blockHistory automation.BlockHistory) int {
+	if len(blockHistory) == 0 {
+		return 2
+	} else {
+		blockHistoryLength := 0
+
+		numberOfFields := len(blockHistory) // should not be counted, used to coordinate values, we don't include retry interval
+
+		objectBraces := 2
+		fieldSeparators := numberOfFields - 1
+
+		for _, block := range blockHistory {
+			blockHistoryLength += blockLength(block)
+		}
+
+		return objectBraces + fieldSeparators + blockHistoryLength
+	}
+}
+
+func blockLength(key automation.BlockKey) int {
+	numberOfFields := 2 // should not be counted, used to coordinate values
+
+	objectBraces := 2
+	numberOfColons := numberOfFields
+	fieldSeparators := numberOfFields - 1
+
+	numberNameAndQuotes := 8
+	hashNameAndQuotes := 6
+
+	valueSizes := 0
+
+	valueSizes += uint64Length(uint64(key.Number))
+	valueSizes += 2 + byte32Length(key.Hash) + len(key.Hash) - 1 // 2 for brackets, length of bytes, length-1 for commas
+
+	return objectBraces + numberOfColons + fieldSeparators + numberNameAndQuotes + hashNameAndQuotes + valueSizes
+}

--- a/pkg/v3/plugin/hooks/estimates/json_test.go
+++ b/pkg/v3/plugin/hooks/estimates/json_test.go
@@ -1,0 +1,320 @@
+package estimates
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObservationLength(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		observation  *ocr2keepers.AutomationObservation
+		expectedJSON string
+		expectedSize int
+	}{
+		{
+			name:         "Empty observation has 63 bytes of JSON",
+			observation:  &ocr2keepers.AutomationObservation{},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":null,"BlockHistory":null}`,
+			expectedSize: 63,
+		},
+		{
+			name: "With non-nil performables, 61 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{},
+			},
+			expectedJSON: `{"Performable":[],"UpkeepProposals":null,"BlockHistory":null}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil upkeep proposals, 61 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+			},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":[],"BlockHistory":null}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil block history, 61 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				BlockHistory: commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":null,"UpkeepProposals":null,"BlockHistory":[]}`,
+			expectedSize: 61,
+		},
+		{
+			name: "With non-nil performable, upkeep proposals and block history, 57 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable:     []commontypes.CheckResult{},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 57,
+		},
+		{
+			name: "With one empty performable, upkeep proposals and block history, 438 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 438,
+		},
+		{
+			name: "With two empty performables, empty upkeep proposals and block history, 820 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{},
+					{},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null},{"PipelineExecutionState":0,"Retryable":false,"Eligible":false,"IneligibilityReason":0,"UpkeepID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Trigger":{"BlockNumber":0,"BlockHash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"LogTriggerExtension":null},"WorkID":"","GasAllocated":0,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 820,
+		},
+		{
+			name: "With one partially populated performable, empty upkeep proposals and block history, 473 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":null},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":null,"FastGasWei":null,"LinkNative":null}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 473,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and block history, 684 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{1, 2, 3, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"AQIDBA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 684,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and block history, 692 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory:    commontypes.BlockHistory{},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[]}`,
+			expectedSize: 692,
+		},
+		{
+			name: "With one fully populated performable, empty upkeep proposals and non empty block history, 955 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
+				BlockHistory: commontypes.BlockHistory{
+					commontypes.BlockKey{
+						Number: 1,
+						Hash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 2,
+						Hash:   [32]byte{2, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 3,
+						Hash:   [32]byte{3, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+				},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[],"BlockHistory":[{"Number":1,"Hash":[1,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":2,"Hash":[2,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":3,"Hash":[3,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]}]}`,
+			expectedSize: 955,
+		},
+		{
+			name: "With one fully populated performable, upkeep proposals and block history, 2283 bytes of JSON",
+			observation: &ocr2keepers.AutomationObservation{
+				Performable: []commontypes.CheckResult{
+					{
+						PipelineExecutionState: 10,
+						Retryable:              true,
+						Eligible:               true,
+						IneligibilityReason:    100,
+						UpkeepID:               commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID:       "workID",
+						GasAllocated: 102003244343430,
+						PerformData:  []byte{11, 255, 255, 4},
+						FastGasWei:   big.NewInt(3242352),
+						LinkNative:   big.NewInt(4535654656436435),
+					},
+				},
+				UpkeepProposals: []commontypes.CoordinatedBlockProposal{
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 102003244343430,
+							BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{11, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{11, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 102003244343430,
+							},
+						},
+						WorkID: "WorkID1",
+					},
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 202003244343430,
+							BlockHash:   [32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{22, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{22, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 202003244343430,
+							},
+						},
+						WorkID: "WorkID2",
+					},
+					{
+						UpkeepID: commontypes.UpkeepIdentifier([32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}),
+						Trigger: commontypes.Trigger{
+							BlockNumber: 302003244343430,
+							BlockHash:   [32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+							LogTriggerExtension: &commontypes.LogTriggerExtension{
+								TxHash:      [32]byte{33, 2, 3, 4, 255, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								Index:       1,
+								BlockHash:   [32]byte{33, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+								BlockNumber: 302003244343430,
+							},
+						},
+						WorkID: "WorkID3",
+					},
+				},
+				BlockHistory: commontypes.BlockHistory{
+					commontypes.BlockKey{
+						Number: 1,
+						Hash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 2,
+						Hash:   [32]byte{2, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+					commontypes.BlockKey{
+						Number: 3,
+						Hash:   [32]byte{3, 2, 3, 4, 5, 6, 7, 8, 1, 244, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8},
+					},
+				},
+			},
+			expectedJSON: `{"Performable":[{"PipelineExecutionState":10,"Retryable":true,"Eligible":true,"IneligibilityReason":100,"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"workID","GasAllocated":102003244343430,"PerformData":"C///BA==","FastGasWei":3242352,"LinkNative":4535654656436435}],"UpkeepProposals":[{"UpkeepID":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":102003244343430,"BlockHash":[11,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[11,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[11,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":102003244343430}},"WorkID":"WorkID1"},{"UpkeepID":[22,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":202003244343430,"BlockHash":[22,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[22,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[22,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":202003244343430}},"WorkID":"WorkID2"},{"UpkeepID":[33,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Trigger":{"BlockNumber":302003244343430,"BlockHash":[33,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"LogTriggerExtension":{"TxHash":[33,2,3,4,255,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"Index":1,"BlockHash":[33,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8],"BlockNumber":302003244343430}},"WorkID":"WorkID3"}],"BlockHistory":[{"Number":1,"Hash":[1,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":2,"Hash":[2,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]},{"Number":3,"Hash":[3,2,3,4,5,6,7,8,1,244,3,4,5,6,7,8,1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8]}]}`,
+			expectedSize: 2283,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.observation)
+			assert.NoError(t, err)
+			assert.Equal(t, len(b), ObservationLength(tc.observation))
+			assert.Equal(t, tc.expectedJSON, string(b))
+			assert.Equal(t, tc.expectedSize, len(b))
+		})
+
+	}
+}

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -71,7 +71,7 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 	if err := plugin.AddConditionalProposalsHook.RunHook(&observation, ocr2keepersv3.ObservationConditionalsProposalsLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr)); err != nil {
 		return nil, err
 	}
-	
+
 	// using the OCR seq number for randomness of the performables ordering.
 	// high randomness results in expesive ordering, therefore we reduce
 	// the range of the randomness by dividing the seq number by 10

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -65,6 +65,13 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 
 	plugin.AddBlockHistoryHook.RunHook(&observation, ocr2keepersv3.ObservationBlockHistoryLimit)
 
+	if err := plugin.AddLogProposalsHook.RunHook(&observation, ocr2keepersv3.ObservationLogRecoveryProposalsLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr)); err != nil {
+		return nil, err
+	}
+	if err := plugin.AddConditionalProposalsHook.RunHook(&observation, ocr2keepersv3.ObservationConditionalsProposalsLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr)); err != nil {
+		return nil, err
+	}
+	
 	// using the OCR seq number for randomness of the performables ordering.
 	// high randomness results in expesive ordering, therefore we reduce
 	// the range of the randomness by dividing the seq number by 10
@@ -73,13 +80,6 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 		return nil, err
 	}
 	prommetrics.AutomationPluginPerformables.WithLabelValues(prommetrics.PluginStepResultStore).Set(float64(len(observation.Performable)))
-
-	if err := plugin.AddLogProposalsHook.RunHook(&observation, ocr2keepersv3.ObservationLogRecoveryProposalsLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr)); err != nil {
-		return nil, err
-	}
-	if err := plugin.AddConditionalProposalsHook.RunHook(&observation, ocr2keepersv3.ObservationConditionalsProposalsLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr)); err != nil {
-		return nil, err
-	}
 
 	plugin.Logger.Printf("built an observation in sequence nr %d with %d performables, %d upkeep proposals and %d block history", outctx.SeqNr, len(observation.Performable), len(observation.UpkeepProposals), len(observation.BlockHistory))
 	prommetrics.AutomationPluginPerformables.WithLabelValues(prommetrics.PluginStepObservation).Set(float64(len(observation.Performable)))

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -635,12 +635,14 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 				hash := crypto.Keccak256(append(uid[:], triggerExtBytes...))
 				return hex.EncodeToString(hash[:])
 			},
-			RemoveFromStagingHook:  hooks.NewRemoveFromStagingHook(resultStore, logger),
-			RemoveFromMetadataHook: hooks.NewRemoveFromMetadataHook(metadataStore, logger),
-			AddToProposalQHook:     hooks.NewAddToProposalQHook(proposalQueue, logger),
-			AddBlockHistoryHook:    hooks.NewAddBlockHistoryHook(metadataStore, logger),
-			AddFromStagingHook:     hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
-			Logger:                 logger,
+			RemoveFromStagingHook:       hooks.NewRemoveFromStagingHook(resultStore, logger),
+			RemoveFromMetadataHook:      hooks.NewRemoveFromMetadataHook(metadataStore, logger),
+			AddToProposalQHook:          hooks.NewAddToProposalQHook(proposalQueue, logger),
+			AddBlockHistoryHook:         hooks.NewAddBlockHistoryHook(metadataStore, logger),
+			AddFromStagingHook:          hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
+			AddLogProposalsHook:         hooks.NewAddLogProposalsHook(metadataStore, coordinator, logger),
+			AddConditionalProposalsHook: hooks.NewAddConditionalProposalsHook(metadataStore, coordinator, logger),
+			Logger:                      logger,
 		}
 
 		previousOutcome := ocr2keepers2.AutomationOutcome{


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-9371

In this PR, we're changing how performables (`CheckResults`) are added to the observation. Rather than always adding a fixed number of performables to the observation, we're now adding performables to the observation, while the observation still has capacity for more performables without exceeding the maximum observation length

## The changes

- Implement a number of `Length` functions for various types that are used within the Observation type
  - These functions calculate the size in bytes of raw JSON representation for specific values 
- Implement three functions for adding performables to the observation (only one will be merged, all three have been included for illustrative purposes)
  - `AddByJSON` - JSON encodes the observation every time we add a performable (accurate, but very expensive)
  - `AddByEstimate` - Use the new estimates package to calculate the raw JSON size of the observation every time we add a performable (inaccurate, but very cheap)
  - `AddByEstimateAggressive` - Uses a combination of the above two functions (accurate, still very cheap)

## Benchmarks

- `AddByJSON`:   ~1315313291 ns/op 🥉 
- `AddByEstimate`:   ~768741 ns/op 🥇 
- `AddByEstimateAggressive`:  ~876293 ns/op 🥈 

## Questions 

- In testing, observations with hundreds of performables have been observed. Should we still apply some limit to the number of performable, e.g. 100?
  - If yes, should we stick to the simpler but less efficient implementation of `AddByEstimate` for adding performables to the observation?




