### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -165,7 +165,7 @@ jobs:
           echo "sonarqube_golangci_report_paths=$(find -type f -name 'golangci-lint-report.xml' -printf "%p,")" >> $GITHUB_OUTPUT
       
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@v2.0.1
+        uses: sonarsource/sonarqube-scan-action@53c3e3207fe4b8d52e2f1ac9d6eb1d2506f626c0 # v2.0.2
         with:
           args: >
             -Dsonar.go.coverage.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_coverage_report_paths }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -124,7 +124,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: go-test-results
+        name: go-race-test-results
         path: ./race_coverage.txt
 
   fuzz-test:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload golangci lint report artifact
       if: always()
-      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: golangci-lint-report
         path: golangci-lint-report.xml
@@ -53,7 +53,7 @@ jobs:
     
     - name: Upload Go test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: go-test-results
         path: ./coverage.txt
@@ -101,7 +101,7 @@ jobs:
     
     - name: Store Simulation Artifacts
       if: always()
-      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ${{ matrix.plan }}_logs
         path: |
@@ -122,7 +122,7 @@ jobs:
     
     - name: Upload Go race test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: go-test-results
         path: ./race_coverage.txt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -41,7 +41,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     # runs-on: ubuntu20.04-64cores-256GB <-- run on specific machine with more resources
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up go
       uses: actions/setup-go@v3
@@ -110,7 +110,7 @@ jobs:
   race-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -130,7 +130,7 @@ jobs:
   fuzz-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -150,7 +150,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -155,7 +155,7 @@ jobs:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       
       - name: Set SonarQube Report Paths
         id: sonarqube_report_paths

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
         go-version-file: "go.mod"
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+      uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc # v5.1.0
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.55.2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
 
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
 
@@ -89,7 +89,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
     
@@ -113,7 +113,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
 
@@ -133,7 +133,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
 

--- a/.github/workflows/scheduled-dependency-check.yaml
+++ b/.github/workflows/scheduled-dependency-check.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version-file: "go.mod"
     

--- a/.github/workflows/scheduled-dependency-check.yaml
+++ b/.github/workflows/scheduled-dependency-check.yaml
@@ -8,7 +8,7 @@ jobs:
   dependency-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/scheduled-dependency-check.yaml
+++ b/.github/workflows/scheduled-dependency-check.yaml
@@ -19,4 +19,4 @@ jobs:
       run: go list -json -m all > go.list
     
     - name: Nancy Scan
-      uses: sonatype-nexus-community/nancy-github-action@main
+      uses: sonatype-nexus-community/nancy-github-action@726e338312e68ecdd4b4195765f174d3b3ce1533 # v1.0.3


### PR DESCRIPTION
## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
[ERROR] Deprecated dependencies found (19)!!
go.yml -> fuzz-test -> actions/checkout@v3 -> node16
go.yml -> fuzz-test -> actions/setup-go@v3 -> node16
go.yml -> lint -> actions/checkout@v3 -> node16
go.yml -> lint -> actions/setup-go@v3 -> node16
go.yml -> lint -> actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 -> node16
go.yml -> lint -> golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc -> node16
go.yml -> race-test -> actions/checkout@v3 -> node16
go.yml -> race-test -> actions/setup-go@v3 -> node16
go.yml -> race-test -> actions/upload-artifact@v3 -> node16
go.yml -> simulation -> actions/checkout@v3 -> node16
go.yml -> simulation -> actions/setup-go@v3 -> node16
go.yml -> simulation -> actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 -> node16
go.yml -> sonar-scan -> actions/checkout@v3 -> node16
go.yml -> sonar-scan -> actions/download-artifact@v3 -> node16
go.yml -> unit-test -> actions/checkout@v3 -> node16
go.yml -> unit-test -> actions/setup-go@v3 -> node16
go.yml -> unit-test -> actions/upload-artifact@v3 -> node16
scheduled-dependency-check.yaml -> dependency-check -> actions/checkout@v3 -> node16
scheduled-dependency-check.yaml -> dependency-check -> actions/setup-go@v3 -> node16
```
