### PR TITLE
Add up to 100 performables based on percentage exceeded

### DIFF
--- a/pkg/v3/observation.go
+++ b/pkg/v3/observation.go
@@ -13,7 +13,7 @@ import (
 // as different nodes would upgrade at different times and would need to
 // adhere to each others' limits
 const (
-	ObservationPerformablesLimit          = 50
+	ObservationPerformablesLimit          = 100
 	ObservationLogRecoveryProposalsLimit  = 5
 	ObservationConditionalsProposalsLimit = 5
 	ObservationBlockHistoryLimit          = 256

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -609,7 +609,7 @@ func TestLargeObservationSize(t *testing.T) {
 	assert.NoError(t, err, "no error in decoding valid automation observation")
 
 	assert.Equal(t, ao, decoded, "final result from encoding and decoding should match")
-	assert.Less(t, len(encoded), MaxObservationLength, "encoded observation should be less than maxObservationSize")
+	assert.Greater(t, len(encoded), MaxObservationLength, "encoded observation will exceed maxObservationSize")
 }
 
 func mockUpkeepTypeGetter(id commontypes.UpkeepIdentifier) types.UpkeepType {

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -576,16 +576,6 @@ func TestObservationSizeWithEmptyPeformables(t *testing.T) {
 			Hash:   [32]byte{1},
 		})
 	}
-	//performData := [5001]byte{}
-	//for i := 0; i < ObservationPerformablesLimit; i++ {
-	//	newResult := validLogResult
-	//	uid := commontypes.UpkeepIdentifier{}
-	//	uid.FromBigInt(big.NewInt(int64(i + 10001)))
-	//	newResult.UpkeepID = uid
-	//	newResult.WorkID = mockWorkIDGenerator(newResult.UpkeepID, newResult.Trigger)
-	//	newResult.PerformData = performData[:]
-	//	ao.Performable = append(ao.Performable, newResult)
-	//}
 	for i := 0; i < ObservationConditionalsProposalsLimit; i++ {
 		newProposal := validConditionalProposal
 		uid := commontypes.UpkeepIdentifier{}

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -564,7 +564,7 @@ func TestInvalidLogProposal(t *testing.T) {
 	assert.ErrorContains(t, err, "log trigger extension cannot be empty for log upkeep")
 }
 
-func TestLargeObservationSize(t *testing.T) {
+func TestObservationSizeWithEmptyPeformables(t *testing.T) {
 	ao := AutomationObservation{
 		Performable:     []commontypes.CheckResult{},
 		UpkeepProposals: []commontypes.CoordinatedBlockProposal{},
@@ -576,16 +576,16 @@ func TestLargeObservationSize(t *testing.T) {
 			Hash:   [32]byte{1},
 		})
 	}
-	performData := [5001]byte{}
-	for i := 0; i < ObservationPerformablesLimit; i++ {
-		newResult := validLogResult
-		uid := commontypes.UpkeepIdentifier{}
-		uid.FromBigInt(big.NewInt(int64(i + 10001)))
-		newResult.UpkeepID = uid
-		newResult.WorkID = mockWorkIDGenerator(newResult.UpkeepID, newResult.Trigger)
-		newResult.PerformData = performData[:]
-		ao.Performable = append(ao.Performable, newResult)
-	}
+	//performData := [5001]byte{}
+	//for i := 0; i < ObservationPerformablesLimit; i++ {
+	//	newResult := validLogResult
+	//	uid := commontypes.UpkeepIdentifier{}
+	//	uid.FromBigInt(big.NewInt(int64(i + 10001)))
+	//	newResult.UpkeepID = uid
+	//	newResult.WorkID = mockWorkIDGenerator(newResult.UpkeepID, newResult.Trigger)
+	//	newResult.PerformData = performData[:]
+	//	ao.Performable = append(ao.Performable, newResult)
+	//}
 	for i := 0; i < ObservationConditionalsProposalsLimit; i++ {
 		newProposal := validConditionalProposal
 		uid := commontypes.UpkeepIdentifier{}
@@ -610,7 +610,7 @@ func TestLargeObservationSize(t *testing.T) {
 
 	assert.Equal(t, ao, decoded, "final result from encoding and decoding should match")
 	assert.Less(t, len(encoded), MaxObservationLength, "encoded observation won't exceed maxObservationSize when perform data is moderately sized")
-	assert.Equal(t, 208404, MaxObservationLength-len(encoded), "we still have 208404 bytes of free space with 100 moderately sized perfromables")
+	assert.Equal(t, 972320, MaxObservationLength-len(encoded), "we still have 972320 bytes of free space for performables")
 }
 
 func mockUpkeepTypeGetter(id commontypes.UpkeepIdentifier) types.UpkeepType {

--- a/pkg/v3/observation_test.go
+++ b/pkg/v3/observation_test.go
@@ -576,14 +576,14 @@ func TestLargeObservationSize(t *testing.T) {
 			Hash:   [32]byte{1},
 		})
 	}
-	largePerformData := [10001]byte{}
+	performData := [5001]byte{}
 	for i := 0; i < ObservationPerformablesLimit; i++ {
 		newResult := validLogResult
 		uid := commontypes.UpkeepIdentifier{}
 		uid.FromBigInt(big.NewInt(int64(i + 10001)))
 		newResult.UpkeepID = uid
 		newResult.WorkID = mockWorkIDGenerator(newResult.UpkeepID, newResult.Trigger)
-		newResult.PerformData = largePerformData[:]
+		newResult.PerformData = performData[:]
 		ao.Performable = append(ao.Performable, newResult)
 	}
 	for i := 0; i < ObservationConditionalsProposalsLimit; i++ {
@@ -609,7 +609,8 @@ func TestLargeObservationSize(t *testing.T) {
 	assert.NoError(t, err, "no error in decoding valid automation observation")
 
 	assert.Equal(t, ao, decoded, "final result from encoding and decoding should match")
-	assert.Greater(t, len(encoded), MaxObservationLength, "encoded observation will exceed maxObservationSize")
+	assert.Less(t, len(encoded), MaxObservationLength, "encoded observation won't exceed maxObservationSize when perform data is moderately sized")
+	assert.Equal(t, 208404, MaxObservationLength-len(encoded), "we still have 208404 bytes of free space with 100 moderately sized perfromables")
 }
 
 func mockUpkeepTypeGetter(id commontypes.UpkeepIdentifier) types.UpkeepType {

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -49,8 +49,13 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 		return err
 	}
 
+	b, err := obs.Encode()
+	if err != nil {
+		return err
+	}
+
 	results = hook.sorter.orderResults(results, rSrc)
-	added, _ := hook.addByPercentageExceeded(obs, limit, results, ocr2keepersv3.ObservationPerformablesLimit)
+	added, _ := hook.addByPercentageExceeded(obs, limit, results, len(b))
 
 	hook.logger.Printf("skipped %d available results in staging", len(results)-added)
 
@@ -63,11 +68,16 @@ func (hook *AddFromStagingHook) addByPercentageExceeded(obs *ocr2keepersv3.Autom
 	if limit > len(results) {
 		limit = len(results)
 	}
+
 	existingPerformables := obs.Performable
+
+	if limit <= 0 {
+		return len(obs.Performable) - len(existingPerformables), 0
+	}
 
 	obs.Performable = append(obs.Performable, results[:limit]...)
 
-	encodings := 1
+	encodingCalls := 1
 	b, _ := obs.Encode()
 
 	if observationSize := len(b); observationSize > ocr2keepersv3.MaxObservationLength {
@@ -76,12 +86,15 @@ func (hook *AddFromStagingHook) addByPercentageExceeded(obs *ocr2keepersv3.Autom
 		exceededBy := observationSize - ocr2keepersv3.MaxObservationLength
 		avgPerformablesExceeded := int(math.Ceil(float64(exceededBy) / float64(avgPerformableSize)))
 		limit -= avgPerformablesExceeded + 1 // ensure we always remove at least one performable on the next call
+		if limit <= 0 {
+			return len(obs.Performable) - len(existingPerformables), encodingCalls
+		}
 		obs.Performable = existingPerformables
 		added, numEncodings := hook.addByPercentageExceeded(obs, limit, results, baseSize)
-		return added, numEncodings + encodings
+		return added, numEncodings + encodingCalls
 	}
 
-	return len(obs.Performable) - len(existingPerformables), encodings
+	return len(obs.Performable) - len(existingPerformables), encodingCalls
 }
 
 type stagedResultSorter struct {

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -69,13 +69,11 @@ func (hook *AddFromStagingHook) addByPercentageExceeded(obs *ocr2keepersv3.Autom
 		limit = len(results)
 	}
 
-	existingPerformables := obs.Performable
-
 	if limit <= 0 {
-		return len(obs.Performable) - len(existingPerformables), 0
+		return len(obs.Performable), 0
 	}
 
-	obs.Performable = append(obs.Performable, results[:limit]...)
+	obs.Performable = results[:limit]
 
 	encodingCalls := 1
 	b, _ := obs.Encode()
@@ -87,14 +85,13 @@ func (hook *AddFromStagingHook) addByPercentageExceeded(obs *ocr2keepersv3.Autom
 		avgPerformablesExceeded := int(math.Ceil(float64(exceededBy) / float64(avgPerformableSize)))
 		limit -= avgPerformablesExceeded + 1 // ensure we always remove at least one performable on the next call
 		if limit <= 0 {
-			return len(obs.Performable) - len(existingPerformables), encodingCalls
+			return len(obs.Performable), encodingCalls
 		}
-		obs.Performable = existingPerformables
 		added, numEncodings := hook.addByPercentageExceeded(obs, limit, results, baseSize)
 		return added, numEncodings + encodingCalls
 	}
 
-	return len(obs.Performable) - len(existingPerformables), encodingCalls
+	return len(obs.Performable), encodingCalls
 }
 
 type stagedResultSorter struct {

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -73,7 +73,7 @@ func TestAddFromStagingHook_RunHook(t *testing.T) {
 			expectedLogMsg:     "adding 2 results to observation",
 		},
 		{
-			name: "Existing results in observation appended",
+			name: "Existing results in observation are overwritten",
 			initialObservation: ocr2keepersv3.AutomationObservation{
 				Performable: []types.CheckResult{{UpkeepID: [32]byte{3}, WorkID: "30a"}},
 			},
@@ -86,7 +86,7 @@ func TestAddFromStagingHook_RunHook(t *testing.T) {
 				{UpkeepID: [32]byte{1}, WorkID: "10c"},
 				{UpkeepID: [32]byte{2}, WorkID: "20b"},
 			},
-			observationWorkIDs: []string{"30a", "20b", "10c"},
+			observationWorkIDs: []string{"20b", "10c"},
 			expectedLogMsg:     "adding 2 results to observation",
 		},
 		{

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -76,6 +76,8 @@ func (plugin *ocr3Plugin) Observation(ctx context.Context, outctx ocr3types.Outc
 	// high randomness results in expesive ordering, therefore we reduce
 	// the range of the randomness by dividing the seq number by 10
 	randSrcSeq := outctx.SeqNr / 10
+
+	// The AddFromStagingHook should always be the last hook that is called as it ensures the size constraints of the observation are met
 	if err := plugin.AddFromStagingHook.RunHook(&observation, ocr2keepersv3.ObservationPerformablesLimit, getRandomKeySource(plugin.ConfigDigest, randSrcSeq)); err != nil {
 		return nil, err
 	}

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -635,12 +635,14 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 				hash := crypto.Keccak256(append(uid[:], triggerExtBytes...))
 				return hex.EncodeToString(hash[:])
 			},
-			RemoveFromStagingHook:  hooks.NewRemoveFromStagingHook(resultStore, logger),
-			RemoveFromMetadataHook: hooks.NewRemoveFromMetadataHook(metadataStore, logger),
-			AddToProposalQHook:     hooks.NewAddToProposalQHook(proposalQueue, logger),
-			AddBlockHistoryHook:    hooks.NewAddBlockHistoryHook(metadataStore, logger),
-			AddFromStagingHook:     hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
-			Logger:                 logger,
+			RemoveFromStagingHook:       hooks.NewRemoveFromStagingHook(resultStore, logger),
+			RemoveFromMetadataHook:      hooks.NewRemoveFromMetadataHook(metadataStore, logger),
+			AddToProposalQHook:          hooks.NewAddToProposalQHook(proposalQueue, logger),
+			AddBlockHistoryHook:         hooks.NewAddBlockHistoryHook(metadataStore, logger),
+			AddFromStagingHook:          hooks.NewAddFromStagingHook(resultStore, coordinator, logger),
+			AddLogProposalsHook:         hooks.NewAddLogProposalsHook(metadataStore, coordinator, logger),
+			AddConditionalProposalsHook: hooks.NewAddConditionalProposalsHook(metadataStore, coordinator, logger),
+			Logger:                      logger,
 		}
 
 		previousOutcome := ocr2keepers2.AutomationOutcome{


### PR DESCRIPTION
See these two previous PRs for context on this change: 

- https://github.com/smartcontractkit/chainlink-automation/pull/325  
- https://github.com/smartcontractkit/chainlink-automation/pull/326 

This change estimates the average size of the performables that have been added, and when we exceed the max observation length, we calculate how far over the max length we are, as a percentage of the total length of performables, and then reduce the number of performables to add based on the average performable size vs the number of bytes we exceeded the max length by. 

When dealing with heavily populated performables (i.e. large perform data), we can fit in ~66 performables into the observation

When dealing with lightly populated performables, we can fit in almost 600 performables into the observation

With this change however, we are applying a limit of 100 performables in the observation, though this can be easily bumped

Node upgrade tests passing: https://github.com/smartcontractkit/chainlink/actions/runs/9318732991
Passing load test (verified through slack): https://github.com/smartcontractkit/chainlink/actions/runs/9318760597