### PR TITLE
retract v1 and return to v0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,3 +72,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+retract [v1.0.0, v1.0.5] // reverting to v0


### PR DESCRIPTION
This PR adds a `retract` to the go mod for versions `v1.0.0` through `v1.0.4`, as well as the superficial version `v1.0.5` that will have to be published to make this official. Afterwards we can tag `v0.8.0` and things will pick up like normal from there. Old builds referencing specific retracted versions will still continue to build, although with a warning. And any future go mod invocations that resolve dependencies will ignore the retracted ones.